### PR TITLE
feat: add user password update api

### DIFF
--- a/DTO/UserDTO/ChangePasswordDTO.cs
+++ b/DTO/UserDTO/ChangePasswordDTO.cs
@@ -1,0 +1,9 @@
+using System;
+
+namespace DTO.UserDTO
+{
+    public class ChangePasswordDTO
+    {
+        public string NewPassword { get; set; } = null!;
+    }
+}

--- a/DTO/UserDTO/ForgotPasswordDTO.cs
+++ b/DTO/UserDTO/ForgotPasswordDTO.cs
@@ -1,0 +1,9 @@
+using System;
+
+namespace DTO.UserDTO
+{
+    public class ForgotPasswordDTO
+    {
+        public string Username { get; set; } = null!;
+    }
+}

--- a/Domain/Contracts/IUserDomain.cs
+++ b/Domain/Contracts/IUserDomain.cs
@@ -20,6 +20,8 @@ namespace Domain.Contracts
         void Logout(string token);
         UserTypeDTO GetUserTypeById(Guid id);
         List<UserTypeDTO> GetAllUserTypes();
+        void ChangePassword(Guid userId, ChangePasswordDTO changePasswordDTO);
+        Task ForgotPassword(ForgotPasswordDTO forgotPasswordDTO);
 
     }
 }

--- a/HumanResourceProject/Controllers/UserController.cs
+++ b/HumanResourceProject/Controllers/UserController.cs
@@ -37,6 +37,22 @@ namespace HumanResourceProject.Controllers
             return Ok();
         }
 
+        [HttpPut]
+        [Route("{userId}/password")]
+        public IActionResult ChangePassword([FromRoute] Guid userId, [FromBody] ChangePasswordDTO changePasswordDTO)
+        {
+            _userDomain.ChangePassword(userId, changePasswordDTO);
+            return Ok();
+        }
+
+        [HttpPost]
+        [Route("forgot-password")]
+        public async Task<IActionResult> ForgotPassword([FromBody] ForgotPasswordDTO forgotPasswordDTO)
+        {
+            await _userDomain.ForgotPassword(forgotPasswordDTO);
+            return Ok();
+        }
+
         [HttpGet]
         [Route("user-type/{userTypeId}")]
         public IActionResult GetUserType([FromRoute] Guid userTypeId)


### PR DESCRIPTION
## Summary
- allow admins to change any user's password
- add domain method to persist password updates
- expose password update endpoint
- implement forgot password logic with email notification

## Testing
- `dotnet build PostOfficeProject.sln` *(fails: bash: command not found: dotnet)*
- `apt-get update` *(fails: The repository 'http://apt.llvm.org/noble llvm-toolchain-noble-20 InRelease' is not signed)*
- `apt-get install -y dotnet-sdk-6.0` *(fails: Unable to locate package dotnet-sdk-6.0)*

------
https://chatgpt.com/codex/tasks/task_e_68ab7e38de0c8332849a937ef1178e29