### PR TITLE
Allow filtering users by user type IDs

### DIFF
--- a/DAL/Concrete/UserRepository.cs
+++ b/DAL/Concrete/UserRepository.cs
@@ -29,8 +29,15 @@ namespace DAL.Concrete
             var filterData = PaginationConfiguration(data, queryParameters.SortField, queryParameters.SortOrder, queryParameters.SearchValue);
             return PagedList<TblUser>.ToPagedList(filterData, queryParameters == null ? 1 : queryParameters.CurrentPage, queryParameters == null ? 10 : queryParameters.PageSize);
 
-        } 
- 
+        }
+
+        public List<TblUser> GetUsersByTypeIds(IEnumerable<Guid> userTypeIds)
+        {
+            return context.Include(x => x.UserType)
+                          .Where(x => x.IsActive && userTypeIds.Contains(x.UserTypeId))
+                          .ToList();
+        }
+
     }
 
 

--- a/DAL/Contracts/IUserRepository.cs
+++ b/DAL/Contracts/IUserRepository.cs
@@ -13,6 +13,7 @@ namespace DAL.Contracts
     {
         PagedList<TblUser> GetAllUsers(QueryParameters queryParameters);
         TblUser CheckIfUsernamExist(string userName);
+        List<TblUser> GetUsersByTypeIds(IEnumerable<Guid> userTypeIds);
 
     }
 }

--- a/Domain/Concrete/UserDomain.cs
+++ b/Domain/Concrete/UserDomain.cs
@@ -9,6 +9,7 @@ using Helpers.Email;
 using Helpers.Pagination;
 using Helpers.PasswordManager;
 using Microsoft.AspNetCore.Http;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 using Microsoft.Extensions.Configuration;
@@ -33,6 +34,15 @@ namespace Domain.Concrete
             users.Data.ForEach(x => { x.UserType = UserTypeRepository.GetById(x.UserTypeId); });
             var paginatedData = Pagination<UserGetDTO>.ToPagedList(users, _mapper.Map<List<UserGetDTO>>);
             return paginatedData;
+        }
+
+        public List<UserGetDTO> GetUsersByTypeIds(List<Guid> userTypeIds)
+        {
+            if (userTypeIds == null || userTypeIds.Count == 0)
+                return new List<UserGetDTO>();
+
+            var users = UserRepository.GetUsersByTypeIds(userTypeIds);
+            return _mapper.Map<List<UserGetDTO>>(users);
         }
 
         public UserGetDTO GetUserById(Guid id)

--- a/Domain/Contracts/IUserDomain.cs
+++ b/Domain/Contracts/IUserDomain.cs
@@ -22,6 +22,7 @@ namespace Domain.Contracts
         List<UserTypeDTO> GetAllUserTypes();
         void ChangePassword(Guid userId, ChangePasswordDTO changePasswordDTO);
         Task ForgotPassword(ForgotPasswordDTO forgotPasswordDTO);
+        List<UserGetDTO> GetUsersByTypeIds(List<Guid> userTypeIds);
 
     }
 }

--- a/HumanResourceProject/Controllers/UserController.cs
+++ b/HumanResourceProject/Controllers/UserController.cs
@@ -2,6 +2,8 @@
 using DTO.UserDTO;
 using Helpers.Pagination;
 using Microsoft.AspNetCore.Mvc;
+using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace HumanResourceProject.Controllers
@@ -23,6 +25,12 @@ namespace HumanResourceProject.Controllers
         [Route("getAll")]
         public IActionResult GetAllUsers([FromQuery] QueryParameters queryParameters)
                     => Ok(_userDomain.GetAllUsers(queryParameters));
+
+
+        [HttpGet]
+        [Route("by-user-types")]
+        public IActionResult GetUsersByTypeIds([FromQuery] List<Guid> userTypeIds)
+                    => Ok(_userDomain.GetUsersByTypeIds(userTypeIds));
 
 
         [HttpGet]


### PR DESCRIPTION
## Summary
- support repository and domain queries that fetch active users by supplied user-type IDs
- expose `/User/by-user-types` endpoint accepting a list of userTypeIds to filter users

## Testing
- `apt-get update` *(fails: repository not signed, 403 Forbidden)*
- `apt-get install -y dotnet-sdk-6.0` *(fails: package not found)*
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae40da57d083329ff649b595770f6c