### PR TITLE
Allow filtering users by user type IDs

### DIFF
--- a/DAL/Concrete/UserRepository.cs
+++ b/DAL/Concrete/UserRepository.cs
@@ -29,8 +29,15 @@ namespace DAL.Concrete
             var filterData = PaginationConfiguration(data, queryParameters.SortField, queryParameters.SortOrder, queryParameters.SearchValue);
             return PagedList<TblUser>.ToPagedList(filterData, queryParameters == null ? 1 : queryParameters.CurrentPage, queryParameters == null ? 10 : queryParameters.PageSize);
 
-        } 
- 
+        }
+
+        public PagedList<TblUser> GetUsersByTypeIds(IEnumerable<Guid> userTypeIds, QueryParameters queryParameters)
+        {
+            var data = context.Where(x => x.IsActive && userTypeIds.Contains(x.UserTypeId));
+            var filterData = PaginationConfiguration(data, queryParameters.SortField, queryParameters.SortOrder, queryParameters.SearchValue);
+            return PagedList<TblUser>.ToPagedList(filterData, queryParameters.CurrentPage, queryParameters.PageSize);
+        }
+
     }
 
 

--- a/DAL/Contracts/IUserRepository.cs
+++ b/DAL/Contracts/IUserRepository.cs
@@ -13,6 +13,7 @@ namespace DAL.Contracts
     {
         PagedList<TblUser> GetAllUsers(QueryParameters queryParameters);
         TblUser CheckIfUsernamExist(string userName);
+        PagedList<TblUser> GetUsersByTypeIds(IEnumerable<Guid> userTypeIds, QueryParameters queryParameters);
 
     }
 }

--- a/Domain/Concrete/UserDomain.cs
+++ b/Domain/Concrete/UserDomain.cs
@@ -9,6 +9,9 @@ using Helpers.Email;
 using Helpers.Pagination;
 using Helpers.PasswordManager;
 using Microsoft.AspNetCore.Http;
+using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 
 using Microsoft.Extensions.Configuration;
@@ -33,6 +36,18 @@ namespace Domain.Concrete
             users.Data.ForEach(x => { x.UserType = UserTypeRepository.GetById(x.UserTypeId); });
             var paginatedData = Pagination<UserGetDTO>.ToPagedList(users, _mapper.Map<List<UserGetDTO>>);
             return paginatedData;
+        }
+
+        public Pagination<UserGetDTO> GetUsersByTypeIds(IEnumerable<Guid> userTypeIds, QueryParameters queryParameters)
+        {
+            if (userTypeIds == null || !userTypeIds.Any())
+            {
+                return new Pagination<UserGetDTO>(new List<UserGetDTO>(), 0, queryParameters.CurrentPage, queryParameters.PageSize);
+            }
+
+            var users = UserRepository.GetUsersByTypeIds(userTypeIds, queryParameters);
+            users.Data.ForEach(x => { x.UserType = UserTypeRepository.GetById(x.UserTypeId); });
+            return Pagination<UserGetDTO>.ToPagedList(users, _mapper.Map<List<UserGetDTO>>);
         }
 
         public UserGetDTO GetUserById(Guid id)

--- a/Domain/Contracts/IUserDomain.cs
+++ b/Domain/Contracts/IUserDomain.cs
@@ -22,6 +22,7 @@ namespace Domain.Contracts
         List<UserTypeDTO> GetAllUserTypes();
         void ChangePassword(Guid userId, ChangePasswordDTO changePasswordDTO);
         Task ForgotPassword(ForgotPasswordDTO forgotPasswordDTO);
+        Pagination<UserGetDTO> GetUsersByTypeIds(IEnumerable<Guid> userTypeIds, QueryParameters queryParameters);
 
     }
 }

--- a/HumanResourceProject/Controllers/UserController.cs
+++ b/HumanResourceProject/Controllers/UserController.cs
@@ -2,6 +2,8 @@
 using DTO.UserDTO;
 using Helpers.Pagination;
 using Microsoft.AspNetCore.Mvc;
+using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace HumanResourceProject.Controllers
@@ -23,6 +25,12 @@ namespace HumanResourceProject.Controllers
         [Route("getAll")]
         public IActionResult GetAllUsers([FromQuery] QueryParameters queryParameters)
                     => Ok(_userDomain.GetAllUsers(queryParameters));
+
+
+        [HttpGet]
+        [Route("by-user-types")]
+        public IActionResult GetUsersByTypeIds([FromQuery] IEnumerable<Guid> userTypeIds, [FromQuery] QueryParameters queryParameters)
+                    => Ok(_userDomain.GetUsersByTypeIds(userTypeIds, queryParameters));
 
 
         [HttpGet]


### PR DESCRIPTION
## Summary
- support repository and domain queries that fetch active users by supplied user-type IDs
- expose `/User/by-user-types` endpoint accepting a list of userTypeIds to filter users
- enable pagination for filtering by user-type IDs via query parameters

## Testing
- `apt-get update` *(fails: repository not signed, 403 Forbidden)*
- `apt-get install -y dotnet-sdk-6.0` *(fails: package not found)*
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae40da57d083329ff649b595770f6c