### PR TITLE
Add optional birthday and address fields to users

### DIFF
--- a/DTO/UserDTO/UserDTO.cs
+++ b/DTO/UserDTO/UserDTO.cs
@@ -14,6 +14,12 @@ namespace DTO.UserDTO
         public string FirstName { get; set; } = null!;
         public string LastName { get; set; } = null!;
         public string Email { get; set; } = null!;
+        public DateTime? Birthday { get; set; }
+        public string? Address { get; set; }
+        public DateTimeOffset? CreatedDate { get; set; }
+        public DateTimeOffset? LastModifiedDate { get; set; }
+        public Guid? CreatedBy { get; set; }
+        public Guid? LastModifiedBy { get; set; }
         public bool IsActive { get; set; }
         public Guid UserTypeId { get; set; }
         public UserTypeGetDTO UserType { get; set; } = null!;
@@ -24,6 +30,8 @@ namespace DTO.UserDTO
         public string FirstName { get; set; } = null!;
         public string LastName { get; set; } = null!;
         public string Email { get; set; } = null!;
+        public DateTime? Birthday { get; set; }
+        public string? Address { get; set; }
         public string Password { get; set; } = null!;
         public Guid UserTypeId { get; set; }
 

--- a/Entities/Models/SchoolAdministrationContext.cs
+++ b/Entities/Models/SchoolAdministrationContext.cs
@@ -325,6 +325,13 @@ namespace Entities.Models
                     .HasMaxLength(255)
                     .IsUnicode(false);
 
+                entity.Property(e => e.Birthday)
+                    .HasColumnType("date");
+
+                entity.Property(e => e.Address)
+                    .HasMaxLength(255)
+                    .IsUnicode(false);
+
                 entity.Property(e => e.Password).IsUnicode(false);
 
                 entity.Property(e => e.Username)

--- a/Entities/Models/TblUser.cs
+++ b/Entities/Models/TblUser.cs
@@ -17,6 +17,8 @@ namespace Entities.Models
         public Guid? LastModifiedBy { get; set; }
         public string Username { get; set; } = null!;
         public string? LastName { get; set; }
+        public DateTime? Birthday { get; set; }
+        public string? Address { get; set; }
 
         public virtual TblUserType UserType { get; set; } = null!;
         public virtual TblStudentCard TblStudentCard { get; set; } = null!;


### PR DESCRIPTION
## Summary
- add Birthday and Address to `TblUser` entity and user DTOs
- configure EF model for new user fields
- surface Created/LastModified audit metadata on `UserGetDTO`

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68ae46f09e8883329f6488617d5add74