### PR TITLE
Add CRUD API for courses

### DIFF
--- a/DAL/Concrete/CourseRepository.cs
+++ b/DAL/Concrete/CourseRepository.cs
@@ -1,17 +1,22 @@
-﻿using DAL.Contracts;
+using DAL.Contracts;
 using Entities.Models;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using Helpers.Pagination;
+using static Helpers.Pagination.QueryParameters;
 
 namespace DAL.Concrete
 {
-    internal class CourseRepository: BaseRepository<TblCourse, Guid>, ICourseRepository
+    internal class CourseRepository : BaseRepository<TblCourse, Guid>, ICourseRepository
     {
         public CourseRepository(SchoolAdministrationContext dbContext) : base(dbContext)
         {
         }
+
+        public PagedList<TblCourse> GetCourses(QueryParameters queryParameters)
+        {
+            var data = context.Where(x => x.IsActive);
+            var filterData = PaginationConfiguration(data, queryParameters.SortField, queryParameters.SortOrder, queryParameters.SearchValue);
+            return PagedList<TblCourse>.ToPagedList(filterData, queryParameters == null ? 1 : queryParameters.CurrentPage, queryParameters == null ? 10 : queryParameters.PageSize);
+        }
     }
 }
+

--- a/DAL/Contracts/ICourseRepository.cs
+++ b/DAL/Contracts/ICourseRepository.cs
@@ -1,14 +1,12 @@
-﻿using DAL.Concrete;
 using Entities.Models;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using Helpers.Pagination;
+using static Helpers.Pagination.QueryParameters;
 
 namespace DAL.Contracts
 {
-    public interface ICourseRepository: IRepository<TblCourse, Guid>
+    public interface ICourseRepository : IRepository<TblCourse, Guid>
     {
+        PagedList<TblCourse> GetCourses(QueryParameters queryParameters);
     }
 }
+

--- a/Domain/Concrete/CourseDomain.cs
+++ b/Domain/Concrete/CourseDomain.cs
@@ -1,0 +1,75 @@
+using AutoMapper;
+using DAL.Contracts;
+using DAL.UoW;
+using Domain.Contracts;
+using DTO;
+using Entities.Models;
+using Helpers.Pagination;
+using Microsoft.AspNetCore.Http;
+
+namespace Domain.Concrete
+{
+    internal class CourseDomain : DomainBase, ICourseDomain
+    {
+        public CourseDomain(IUnitOfWork unitOfWork, IMapper mapper, IHttpContextAccessor httpContextAccessor) : base(unitOfWork, mapper, httpContextAccessor)
+        {
+        }
+
+        private ICourseRepository CourseRepository => _unitOfWork.GetRepository<ICourseRepository>();
+
+        public void AddNew(CoursePostDTO course)
+        {
+            var entity = _mapper.Map<TblCourse>(course);
+            entity.Id = Guid.NewGuid();
+            if (!course.IsActive.HasValue)
+                entity.IsActive = true;
+            CourseRepository.Add(entity);
+            _unitOfWork.Save();
+        }
+
+        public void Delete(Guid id)
+        {
+            CourseRepository.Remove(id);
+        }
+
+        public Pagination<CourseDTO> GetAllCourses(QueryParameters queryParameters)
+        {
+            var courses = CourseRepository.GetCourses(queryParameters);
+            var paginatedData = Pagination<CourseDTO>.ToPagedList(courses, _mapper.Map<List<CourseDTO>>);
+            return paginatedData;
+        }
+
+        public CourseDTO GetCourseById(Guid id)
+        {
+            var entity = CourseRepository.GetById(id);
+            if (entity == null)
+            {
+                throw new Exception("Course not found");
+            }
+            return _mapper.Map<CourseDTO>(entity);
+        }
+
+        public CourseDTO Update(Guid id, CoursePostDTO course)
+        {
+            var entity = CourseRepository.GetById(id);
+            if (entity == null)
+            {
+                throw new Exception("Course not found");
+            }
+            if (!string.IsNullOrWhiteSpace(course.Name))
+                entity.Name = course.Name;
+            if (course.Credits.HasValue)
+                entity.Credits = course.Credits.Value;
+            if (course.TotalHours.HasValue)
+                entity.TotalHours = course.TotalHours.Value;
+            if (course.IsActive.HasValue)
+                entity.IsActive = course.IsActive.Value;
+            if (course.DepartmantId.HasValue)
+                entity.DepartmentId = course.DepartmantId.Value;
+            CourseRepository.SetModified(entity);
+            _unitOfWork.Save();
+            return _mapper.Map<CourseDTO>(entity);
+        }
+    }
+}
+

--- a/Domain/Contracts/ICourseDomain.cs
+++ b/Domain/Contracts/ICourseDomain.cs
@@ -1,0 +1,15 @@
+using DTO;
+using Helpers.Pagination;
+
+namespace Domain.Contracts
+{
+    public interface ICourseDomain
+    {
+        Pagination<CourseDTO> GetAllCourses(QueryParameters queryParameters);
+        CourseDTO GetCourseById(Guid id);
+        void AddNew(CoursePostDTO course);
+        CourseDTO Update(Guid id, CoursePostDTO course);
+        void Delete(Guid id);
+    }
+}
+

--- a/Domain/DI/DomainRegistry.cs
+++ b/Domain/DI/DomainRegistry.cs
@@ -22,6 +22,7 @@ namespace Domain.DI
             For<IAcademicYearDomain>().Use<AcademicYearDomain>();
             For<IAttendanceDomain>().Use<AttendanceDomain>();
             For<IRoomDomain>().Use<RoomDomain>();
+            For<ICourseDomain>().Use<CourseDomain>();
 
             AddRepositoryRegistries();
             AddHttpContextRegistries();

--- a/HumanResourceProject/Controllers/CourseController.cs
+++ b/HumanResourceProject/Controllers/CourseController.cs
@@ -1,0 +1,51 @@
+using Domain.Contracts;
+using DTO;
+using Helpers.Pagination;
+using Microsoft.AspNetCore.Mvc;
+
+namespace PostOfficeProject.Controllers
+{
+    [ApiController]
+    [Route("[controller]")]
+    public class CourseController : ControllerBase
+    {
+        private readonly ICourseDomain _courseDomain;
+
+        public CourseController(ICourseDomain courseDomain)
+        {
+            _courseDomain = courseDomain;
+        }
+
+        [HttpPost]
+        [Route("getAll")]
+        public IActionResult GetAll([FromQuery] QueryParameters queryParameters)
+            => Ok(_courseDomain.GetAllCourses(queryParameters));
+
+        [HttpGet]
+        [Route("{id}")]
+        public IActionResult GetById([FromRoute] Guid id)
+            => Ok(_courseDomain.GetCourseById(id));
+
+        [HttpPost]
+        [Route("add")]
+        public IActionResult AddNew([FromBody] CoursePostDTO dto)
+        {
+            _courseDomain.AddNew(dto);
+            return Ok();
+        }
+
+        [HttpPatch]
+        [Route("{id}")]
+        public IActionResult Update([FromRoute] Guid id, [FromBody] CoursePostDTO dto)
+            => Ok(_courseDomain.Update(id, dto));
+
+        [HttpDelete]
+        [Route("{id}")]
+        public IActionResult Delete([FromRoute] Guid id)
+        {
+            _courseDomain.Delete(id);
+            return Ok();
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- extend course repository with paginated retrieval
- implement course domain and register in DI container
- expose course CRUD endpoints via CourseController

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae53b423b88332be0fdc0c9d816a41