### PR TITLE
Add global exception handling middleware

### DIFF
--- a/HumanResourceProject/Middlewares/ExceptionMiddleware.cs
+++ b/HumanResourceProject/Middlewares/ExceptionMiddleware.cs
@@ -1,0 +1,48 @@
+using HumanResourceProject.Models;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using System.Net;
+
+namespace HumanResourceProject.Middlewares
+{
+    public class ExceptionMiddleware
+    {
+        private readonly RequestDelegate _next;
+        private readonly ILogger<ExceptionMiddleware> _logger;
+
+        public ExceptionMiddleware(RequestDelegate next, ILogger<ExceptionMiddleware> logger)
+        {
+            _next = next;
+            _logger = logger;
+        }
+
+        public async Task InvokeAsync(HttpContext context)
+        {
+            try
+            {
+                await _next(context);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Unhandled exception");
+                context.Response.ContentType = "application/json";
+                context.Response.StatusCode = (int)HttpStatusCode.InternalServerError;
+                var response = new ErrorResponse
+                {
+                    StatusCode = context.Response.StatusCode,
+                    Message = ex.Message
+                };
+                await context.Response.WriteAsJsonAsync(response);
+            }
+        }
+    }
+
+    public static class ExceptionMiddlewareExtensions
+    {
+        public static IApplicationBuilder UseExceptionHandling(this IApplicationBuilder app)
+        {
+            return app.UseMiddleware<ExceptionMiddleware>();
+        }
+    }
+}

--- a/HumanResourceProject/Models/ErrorResponse.cs
+++ b/HumanResourceProject/Models/ErrorResponse.cs
@@ -1,0 +1,8 @@
+namespace HumanResourceProject.Models
+{
+    public class ErrorResponse
+    {
+        public int StatusCode { get; set; }
+        public string Message { get; set; } = string.Empty;
+    }
+}

--- a/HumanResourceProject/Program.cs
+++ b/HumanResourceProject/Program.cs
@@ -3,6 +3,7 @@ using DI;
 using Domain.Mappings;
 using Entities.Models;
 using Helpers.Email;
+using HumanResourceProject.Middlewares;
 using Lamar.Microsoft.DependencyInjection;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Authorization;
@@ -106,6 +107,7 @@ builder.Host.UseLamar((context, registry) =>
 
 
 var app = builder.Build();
+app.UseExceptionHandling();
 app.UseCors("AllowAll");
 app.UseAuthentication();
 app.UseAuthorization();


### PR DESCRIPTION
## Summary
- add `ErrorResponse` DTO to wrap error details
- implement `ExceptionMiddleware` and extension for unified JSON error responses
- hook middleware into the request pipeline

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b243d717ac8332b20afb25eb76c940