### PR TITLE
Enable group-student association management

### DIFF
--- a/DAL/Concrete/GroupStudentRepository.cs
+++ b/DAL/Concrete/GroupStudentRepository.cs
@@ -1,0 +1,13 @@
+using System;
+using DAL.Contracts;
+using Entities.Models;
+
+namespace DAL.Concrete
+{
+    internal class GroupStudentRepository : BaseRepository<TblGroupStudent, Guid>, IGroupStudentRepository
+    {
+        public GroupStudentRepository(SchoolAdministrationContext dbContext) : base(dbContext)
+        {
+        }
+    }
+}

--- a/DAL/Contracts/IGroupStudentRepository.cs
+++ b/DAL/Contracts/IGroupStudentRepository.cs
@@ -1,0 +1,9 @@
+using System;
+using Entities.Models;
+
+namespace DAL.Contracts
+{
+    public interface IGroupStudentRepository : IRepository<TblGroupStudent, Guid>
+    {
+    }
+}

--- a/DAL/DI/RepositoryRegistry.cs
+++ b/DAL/DI/RepositoryRegistry.cs
@@ -24,6 +24,7 @@ namespace DAL.DI
             For<IRoomRepository>().Use<RoomRepository>();
             For<IStudentCardRepository>().Use<StudentCardRepository>();
             For<IGroupRepository>().Use<GroupRepository>();
+            For<IGroupStudentRepository>().Use<GroupStudentRepository>();
             For<IScheduleRepository>().Use<ScheduleRepository>();
             //    For<IHistoryRepository>().Use<HistoryRepository>();
             //    For<IPostOfficeRepository>().Use<PostOfficeRepository>();

--- a/DTO/GroupDTO.cs
+++ b/DTO/GroupDTO.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 
 namespace DTO
 {
@@ -15,5 +16,6 @@ namespace DTO
         public string? Name { get; set; }
         public Guid? CourseId { get; set; }
         public Guid? AcademicYearId { get; set; }
+        public List<Guid>? StudentIds { get; set; }
     }
 }

--- a/DTO/GroupStudentDTO.cs
+++ b/DTO/GroupStudentDTO.cs
@@ -1,0 +1,10 @@
+using System;
+using System.Collections.Generic;
+
+namespace DTO
+{
+    public class GroupStudentPostDTO
+    {
+        public List<Guid> StudentIds { get; set; } = new();
+    }
+}

--- a/Domain/Concrete/GroupDomain.cs
+++ b/Domain/Concrete/GroupDomain.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Linq;
 using AutoMapper;
 using DAL.Contracts;
 using DAL.UoW;
@@ -16,12 +18,23 @@ namespace Domain.Concrete
         }
 
         private IGroupRepository GroupRepository => _unitOfWork.GetRepository<IGroupRepository>();
+        private IGroupStudentRepository GroupStudentRepository => _unitOfWork.GetRepository<IGroupStudentRepository>();
 
         public void AddNew(GroupPostDTO group)
         {
             var entity = _mapper.Map<TblGroup>(group);
             entity.Id = Guid.NewGuid();
             GroupRepository.Add(entity);
+            if (group.StudentIds != null && group.StudentIds.Any())
+            {
+                var groupStudents = group.StudentIds.Select(studentId => new TblGroupStudent
+                {
+                    Id = Guid.NewGuid(),
+                    GroupId = entity.Id,
+                    StudentId = studentId
+                });
+                GroupStudentRepository.AddRange(groupStudents);
+            }
             _unitOfWork.Save();
         }
 
@@ -64,6 +77,37 @@ namespace Domain.Concrete
             GroupRepository.SetModified(entity);
             _unitOfWork.Save();
             return _mapper.Map<GroupDTO>(entity);
+        }
+
+        public void AddStudents(Guid groupId, GroupStudentPostDTO dto)
+        {
+            var group = GroupRepository.GetById(groupId);
+            if (group == null)
+            {
+                throw new Exception("Group not found");
+            }
+            if (dto.StudentIds == null || !dto.StudentIds.Any())
+                return;
+
+            var entities = dto.StudentIds.Select(id => new TblGroupStudent
+            {
+                Id = Guid.NewGuid(),
+                GroupId = groupId,
+                StudentId = id
+            });
+            GroupStudentRepository.AddRange(entities);
+            _unitOfWork.Save();
+        }
+
+        public void RemoveStudents(Guid groupId, GroupStudentPostDTO dto)
+        {
+            if (dto.StudentIds == null || !dto.StudentIds.Any())
+                return;
+            var entities = GroupStudentRepository
+                .Find(x => x.GroupId == groupId && dto.StudentIds.Contains(x.StudentId))
+                .ToList();
+            GroupStudentRepository.RemoveRange(entities);
+            _unitOfWork.Save();
         }
     }
 }

--- a/Domain/Contracts/IGroupDomain.cs
+++ b/Domain/Contracts/IGroupDomain.cs
@@ -1,3 +1,4 @@
+using System;
 using DTO;
 using Helpers.Pagination;
 
@@ -10,5 +11,7 @@ namespace Domain.Contracts
         void AddNew(GroupPostDTO group);
         GroupDTO Update(Guid id, GroupPostDTO group);
         void Delete(Guid id);
+        void AddStudents(Guid groupId, GroupStudentPostDTO dto);
+        void RemoveStudents(Guid groupId, GroupStudentPostDTO dto);
     }
 }

--- a/HumanResourceProject/Controllers/GroupController.cs
+++ b/HumanResourceProject/Controllers/GroupController.cs
@@ -2,6 +2,7 @@ using Domain.Contracts;
 using DTO;
 using Helpers.Pagination;
 using Microsoft.AspNetCore.Mvc;
+using System;
 
 namespace PostOfficeProject.Controllers
 {
@@ -31,6 +32,22 @@ namespace PostOfficeProject.Controllers
         public IActionResult AddNew([FromBody] GroupPostDTO dto)
         {
             _groupDomain.AddNew(dto);
+            return Ok();
+        }
+
+        [HttpPost]
+        [Route("{id}/students")]
+        public IActionResult AddStudents([FromRoute] Guid id, [FromBody] GroupStudentPostDTO dto)
+        {
+            _groupDomain.AddStudents(id, dto);
+            return Ok();
+        }
+
+        [HttpDelete]
+        [Route("{id}/students")]
+        public IActionResult RemoveStudents([FromRoute] Guid id, [FromBody] GroupStudentPostDTO dto)
+        {
+            _groupDomain.RemoveStudents(id, dto);
             return Ok();
         }
 


### PR DESCRIPTION
## Summary
- allow group creation to include students
- add endpoints to attach or detach students from groups
- support persistence and DI for group-student relations

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b253df16f883329c212550b9e60689