### PR TITLE
Expose course and academic year details for groups with student ID listing

### DIFF
--- a/DAL/Concrete/GroupRepository.cs
+++ b/DAL/Concrete/GroupRepository.cs
@@ -1,6 +1,8 @@
 using DAL.Contracts;
 using Entities.Models;
 using Helpers.Pagination;
+using Microsoft.EntityFrameworkCore;
+using System.Linq;
 using static Helpers.Pagination.QueryParameters;
 
 namespace DAL.Concrete
@@ -13,9 +15,22 @@ namespace DAL.Concrete
 
         public PagedList<TblGroup> GetGroups(QueryParameters queryParameters)
         {
-            var data = context;
+            var data = context
+                .Include(g => g.Course)
+                .Include(g => g.AcademicYear)
+                .Include(g => g.TblGroupStudents);
+
             var filterData = PaginationConfiguration(data, queryParameters.SortField, queryParameters.SortOrder, queryParameters.SearchValue);
             return PagedList<TblGroup>.ToPagedList(filterData, queryParameters == null ? 1 : queryParameters.CurrentPage, queryParameters == null ? 10 : queryParameters.PageSize);
+        }
+
+        public override TblGroup GetById(Guid id)
+        {
+            return context
+                .Include(g => g.Course)
+                .Include(g => g.AcademicYear)
+                .Include(g => g.TblGroupStudents)
+                .FirstOrDefault(g => g.Id == id);
         }
     }
 }

--- a/DAL/Concrete/GroupStudentRepository.cs
+++ b/DAL/Concrete/GroupStudentRepository.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using DAL.Contracts;
 using Entities.Models;
 
@@ -8,6 +10,14 @@ namespace DAL.Concrete
     {
         public GroupStudentRepository(SchoolAdministrationContext dbContext) : base(dbContext)
         {
+        }
+
+        public IEnumerable<Guid> GetStudentIdsByGroupId(Guid groupId)
+        {
+            return context
+                .Where(x => x.GroupId == groupId)
+                .Select(x => x.StudentId)
+                .ToList();
         }
     }
 }

--- a/DAL/Contracts/IGroupStudentRepository.cs
+++ b/DAL/Contracts/IGroupStudentRepository.cs
@@ -1,9 +1,11 @@
 using System;
+using System.Collections.Generic;
 using Entities.Models;
 
 namespace DAL.Contracts
 {
     public interface IGroupStudentRepository : IRepository<TblGroupStudent, Guid>
     {
+        IEnumerable<Guid> GetStudentIdsByGroupId(Guid groupId);
     }
 }

--- a/DTO/GroupDTO.cs
+++ b/DTO/GroupDTO.cs
@@ -9,6 +9,10 @@ namespace DTO
         public string Name { get; set; }
         public Guid CourseId { get; set; }
         public Guid AcademicYearId { get; set; }
+        public CourseDTO Course { get; set; }
+        public AcademicYearDTO AcademicYear { get; set; }
+        public List<Guid> StudentIds { get; set; }
+        public int StudentsLength { get; set; }
     }
 
     public class GroupPostDTO

--- a/Domain/Concrete/GroupDomain.cs
+++ b/Domain/Concrete/GroupDomain.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using AutoMapper;
 using DAL.Contracts;
@@ -108,6 +109,11 @@ namespace Domain.Concrete
                 .ToList();
             GroupStudentRepository.RemoveRange(entities);
             _unitOfWork.Save();
+        }
+
+        public IEnumerable<Guid> GetStudents(Guid groupId)
+        {
+            return GroupStudentRepository.GetStudentIdsByGroupId(groupId);
         }
     }
 }

--- a/Domain/Contracts/IGroupDomain.cs
+++ b/Domain/Contracts/IGroupDomain.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using DTO;
 using Helpers.Pagination;
 
@@ -13,5 +14,6 @@ namespace Domain.Contracts
         void Delete(Guid id);
         void AddStudents(Guid groupId, GroupStudentPostDTO dto);
         void RemoveStudents(Guid groupId, GroupStudentPostDTO dto);
+        IEnumerable<Guid> GetStudents(Guid groupId);
     }
 }

--- a/Domain/Mappings/GeneralProfile.cs
+++ b/Domain/Mappings/GeneralProfile.cs
@@ -9,6 +9,7 @@ using DTO.UserDTO;
 using DTO.UserTypeDTO;
 using Entities.Models;
 using Newtonsoft.Json;
+using System.Linq;
 
 namespace Domain.Mappings
 {
@@ -70,7 +71,15 @@ namespace Domain.Mappings
             CreateMap<TblAttendance, AttendanceCheckInDTO>().ReverseMap();
             #endregion
             #region groups
-            CreateMap<TblGroup, GroupDTO>().ReverseMap();
+            CreateMap<TblGroup, GroupDTO>()
+                .ForMember(dest => dest.Course, opt => opt.MapFrom(src => src.Course))
+                .ForMember(dest => dest.AcademicYear, opt => opt.MapFrom(src => src.AcademicYear))
+                .ForMember(dest => dest.StudentIds, opt => opt.MapFrom(src => src.TblGroupStudents.Select(gs => gs.StudentId)))
+                .ForMember(dest => dest.StudentsLength, opt => opt.MapFrom(src => src.TblGroupStudents.Count))
+                .ReverseMap()
+                .ForMember(dest => dest.Course, opt => opt.Ignore())
+                .ForMember(dest => dest.AcademicYear, opt => opt.Ignore())
+                .ForMember(dest => dest.TblGroupStudents, opt => opt.Ignore());
             CreateMap<TblGroup, GroupPostDTO>().ReverseMap();
             #endregion
             #region schedules

--- a/HumanResourceProject/Controllers/GroupController.cs
+++ b/HumanResourceProject/Controllers/GroupController.cs
@@ -35,6 +35,11 @@ namespace PostOfficeProject.Controllers
             return Ok();
         }
 
+        [HttpGet]
+        [Route("{id}/students")]
+        public IActionResult GetStudents([FromRoute] Guid id)
+            => Ok(_groupDomain.GetStudents(id));
+
         [HttpPost]
         [Route("{id}/students")]
         public IActionResult AddStudents([FromRoute] Guid id, [FromBody] GroupStudentPostDTO dto)


### PR DESCRIPTION
## Summary
- include course and academic year objects with each group plus student ID list and count
- return student IDs instead of full user records when listing a group's students

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b259286a208332a13e913d257edcd2