### PR TITLE
Handle duplicate group-student associations

### DIFF
--- a/Domain/Concrete/GroupDomain.cs
+++ b/Domain/Concrete/GroupDomain.cs
@@ -28,7 +28,8 @@ namespace Domain.Concrete
             GroupRepository.Add(entity);
             if (group.StudentIds != null && group.StudentIds.Any())
             {
-                var groupStudents = group.StudentIds.Select(studentId => new TblGroupStudent
+                var uniqueIds = group.StudentIds.Distinct();
+                var groupStudents = uniqueIds.Select(studentId => new TblGroupStudent
                 {
                     Id = Guid.NewGuid(),
                     GroupId = entity.Id,
@@ -90,12 +91,25 @@ namespace Domain.Concrete
             if (dto.StudentIds == null || !dto.StudentIds.Any())
                 return;
 
-            var entities = dto.StudentIds.Select(id => new TblGroupStudent
-            {
-                Id = Guid.NewGuid(),
-                GroupId = groupId,
-                StudentId = id
-            });
+            var existingIds = GroupStudentRepository
+                .Find(x => x.GroupId == groupId && dto.StudentIds.Contains(x.StudentId))
+                .Select(x => x.StudentId)
+                .ToHashSet();
+
+            var entities = dto.StudentIds
+                .Where(id => !existingIds.Contains(id))
+                .Distinct()
+                .Select(id => new TblGroupStudent
+                {
+                    Id = Guid.NewGuid(),
+                    GroupId = groupId,
+                    StudentId = id
+                })
+                .ToList();
+
+            if (!entities.Any())
+                return;
+
             GroupStudentRepository.AddRange(entities);
             _unitOfWork.Save();
         }


### PR DESCRIPTION
## Summary
- ensure new groups only persist unique student IDs
- skip adding existing students to a group

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b3064aab388332a6ffc06353533077