### PR TITLE
Use DateTime for schedule times

### DIFF
--- a/DTO/ScheduleDTO.cs
+++ b/DTO/ScheduleDTO.cs
@@ -12,8 +12,8 @@ namespace DTO
         public Guid RoomId { get; set; }
         public Guid AcademicYearId { get; set; }
         public Helpers.DayOfWeek DayOfWeek { get; set; }
-        public TimeSpan StartTime { get; set; }
-        public TimeSpan EndTime { get; set; }
+        public DateTime StartTime { get; set; }
+        public DateTime EndTime { get; set; }
         public RoomType ScheduleType { get; set; }
     }
 
@@ -25,8 +25,8 @@ namespace DTO
         public Guid? RoomId { get; set; }
         public Guid? AcademicYearId { get; set; }
         public Helpers.DayOfWeek? DayOfWeek { get; set; }
-        public TimeSpan? StartTime { get; set; }
-        public TimeSpan? EndTime { get; set; }
+        public DateTime? StartTime { get; set; }
+        public DateTime? EndTime { get; set; }
         public RoomType? ScheduleType { get; set; }
     }
 }

--- a/Entities/Models/TblSchedule.cs
+++ b/Entities/Models/TblSchedule.cs
@@ -18,8 +18,8 @@ namespace Entities.Models
         public Guid RoomId { get; set; }
         public Guid AcademicYearId { get; set; }
         public Helpers.DayOfWeek DayOfWeek { get; set; }
-        public TimeSpan StartTime { get; set; }
-        public TimeSpan EndTime { get; set; }
+        public DateTime StartTime { get; set; }
+        public DateTime EndTime { get; set; }
         public RoomType ScheduleType { get; set; }
 
         public virtual TblCourse Course { get; set; } = null!;


### PR DESCRIPTION
## Summary
- Switch schedule StartTime and EndTime fields from `TimeSpan` to `DateTime` to accept full ISO 8601 timestamps.

## Testing
- `dotnet build PostOfficeProject.sln` *(fails: command not found: dotnet)*
- `apt-get update` *(fails: repository is not signed, 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b31bfedc5483329eece888c57b31fe