### PR TITLE
Include user data in teacher CRUD results

### DIFF
--- a/DAL/Concrete/TeacherRepository.cs
+++ b/DAL/Concrete/TeacherRepository.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Linq;
+using DAL.Contracts;
+using Entities.Models;
+using Helpers.Pagination;
+using Microsoft.EntityFrameworkCore;
+using static Helpers.Pagination.QueryParameters;
+
+namespace DAL.Concrete
+{
+    internal class TeacherRepository : BaseRepository<TblTeacher, Guid>, ITeacherRepository
+    {
+        public TeacherRepository(SchoolAdministrationContext dbContext) : base(dbContext)
+        {
+        }
+
+        public PagedList<TblTeacher> GetTeachers(QueryParameters queryParameters)
+        {
+            var data = context.Include(t => t.User);
+            var filterData = PaginationConfiguration(data, queryParameters.SortField, queryParameters.SortOrder, queryParameters.SearchValue);
+            return PagedList<TblTeacher>.ToPagedList(filterData, queryParameters == null ? 1 : queryParameters.CurrentPage, queryParameters == null ? 10 : queryParameters.PageSize);
+        }
+
+        public override TblTeacher GetById(Guid id)
+        {
+            return context.Include(t => t.User).FirstOrDefault(t => t.Id == id);
+        }
+    }
+}

--- a/DAL/Contracts/ITeacherRepository.cs
+++ b/DAL/Contracts/ITeacherRepository.cs
@@ -1,0 +1,11 @@
+using Entities.Models;
+using Helpers.Pagination;
+using static Helpers.Pagination.QueryParameters;
+
+namespace DAL.Contracts
+{
+    public interface ITeacherRepository : IRepository<TblTeacher, Guid>
+    {
+        PagedList<TblTeacher> GetTeachers(QueryParameters queryParameters);
+    }
+}

--- a/DAL/DI/RepositoryRegistry.cs
+++ b/DAL/DI/RepositoryRegistry.cs
@@ -25,6 +25,7 @@ namespace DAL.DI
             For<IStudentCardRepository>().Use<StudentCardRepository>();
             For<IGroupRepository>().Use<GroupRepository>();
             For<IGroupStudentRepository>().Use<GroupStudentRepository>();
+            For<ITeacherRepository>().Use<TeacherRepository>();
             For<IScheduleRepository>().Use<ScheduleRepository>();
             //    For<IHistoryRepository>().Use<HistoryRepository>();
             //    For<IPostOfficeRepository>().Use<PostOfficeRepository>();

--- a/DTO/TeacherDTO.cs
+++ b/DTO/TeacherDTO.cs
@@ -1,0 +1,17 @@
+using System;
+using DTO.UserDTO;
+
+namespace DTO
+{
+    public class TeacherDTO
+    {
+        public Guid Id { get; set; }
+        public Guid UserId { get; set; }
+        public UserSimpleDTO User { get; set; } = null!;
+    }
+
+    public class TeacherPostDTO
+    {
+        public Guid? UserId { get; set; }
+    }
+}

--- a/Domain/Concrete/TeacherDomain.cs
+++ b/Domain/Concrete/TeacherDomain.cs
@@ -1,0 +1,75 @@
+using System;
+using System.Collections.Generic;
+using AutoMapper;
+using DAL.Contracts;
+using DAL.UoW;
+using Domain.Contracts;
+using DTO;
+using Entities.Models;
+using Helpers.Pagination;
+using Microsoft.AspNetCore.Http;
+
+namespace Domain.Concrete
+{
+    internal class TeacherDomain : DomainBase, ITeacherDomain
+    {
+        public TeacherDomain(IUnitOfWork unitOfWork, IMapper mapper, IHttpContextAccessor httpContextAccessor) : base(unitOfWork, mapper, httpContextAccessor)
+        {
+        }
+
+        private ITeacherRepository TeacherRepository => _unitOfWork.GetRepository<ITeacherRepository>();
+
+        public TeacherDTO AddNew(TeacherPostDTO teacherPostDTO)
+        {
+            if (!teacherPostDTO.UserId.HasValue)
+                throw new Exception("Missing required data");
+
+            var entity = _mapper.Map<TblTeacher>(teacherPostDTO);
+            entity.Id = Guid.NewGuid();
+            TeacherRepository.Add(entity);
+            _unitOfWork.Save();
+
+            var created = TeacherRepository.GetById(entity.Id);
+            return _mapper.Map<TeacherDTO>(created);
+        }
+
+        public void Delete(Guid id)
+        {
+            TeacherRepository.Remove(id);
+            _unitOfWork.Save();
+        }
+
+        public Pagination<TeacherDTO> GetAllTeachers(QueryParameters queryParameters)
+        {
+            var teachers = TeacherRepository.GetTeachers(queryParameters);
+            var paginatedData = Pagination<TeacherDTO>.ToPagedList(teachers, _mapper.Map<List<TeacherDTO>>);
+            return paginatedData;
+        }
+
+        public TeacherDTO GetTeacherById(Guid id)
+        {
+            var entity = TeacherRepository.GetById(id);
+            if (entity == null)
+            {
+                throw new Exception("Teacher not found");
+            }
+            return _mapper.Map<TeacherDTO>(entity);
+        }
+
+        public TeacherDTO Update(Guid id, TeacherPostDTO teacherPostDTO)
+        {
+            var entity = TeacherRepository.GetById(id);
+            if (entity == null)
+            {
+                throw new Exception("Teacher not found");
+            }
+            if (teacherPostDTO.UserId.HasValue)
+                entity.UserId = teacherPostDTO.UserId.Value;
+            TeacherRepository.SetModified(entity);
+            _unitOfWork.Save();
+
+            var updated = TeacherRepository.GetById(id);
+            return _mapper.Map<TeacherDTO>(updated);
+        }
+    }
+}

--- a/Domain/Contracts/ITeacherDomain.cs
+++ b/Domain/Contracts/ITeacherDomain.cs
@@ -1,0 +1,14 @@
+using DTO;
+using Helpers.Pagination;
+
+namespace Domain.Contracts
+{
+    public interface ITeacherDomain
+    {
+        Pagination<TeacherDTO> GetAllTeachers(QueryParameters queryParameters);
+        TeacherDTO GetTeacherById(Guid id);
+        TeacherDTO AddNew(TeacherPostDTO teacherPostDTO);
+        TeacherDTO Update(Guid id, TeacherPostDTO teacherPostDTO);
+        void Delete(Guid id);
+    }
+}

--- a/Domain/DI/DomainRegistry.cs
+++ b/Domain/DI/DomainRegistry.cs
@@ -25,6 +25,7 @@ namespace Domain.DI
             For<ICourseDomain>().Use<CourseDomain>();
             For<IStudentCardDomain>().Use<StudentCardDomain>();
             For<IGroupDomain>().Use<GroupDomain>();
+            For<ITeacherDomain>().Use<TeacherDomain>();
             For<IScheduleDomain>().Use<ScheduleDomain>();
 
             AddRepositoryRegistries();

--- a/Domain/Mappings/GeneralProfile.cs
+++ b/Domain/Mappings/GeneralProfile.cs
@@ -70,6 +70,13 @@ namespace Domain.Mappings
             CreateMap<TblAttendance, AttendanceDTO>().ReverseMap();
             CreateMap<TblAttendance, AttendanceCheckInDTO>().ReverseMap();
             #endregion
+            #region teachers
+            CreateMap<TblTeacher, TeacherDTO>()
+                .ForMember(dest => dest.User, opt => opt.MapFrom(src => src.User))
+                .ReverseMap()
+                .ForMember(dest => dest.User, opt => opt.Ignore());
+            CreateMap<TblTeacher, TeacherPostDTO>().ReverseMap();
+            #endregion
             #region groups
             CreateMap<TblGroup, GroupDTO>()
                 .ForMember(dest => dest.Course, opt => opt.MapFrom(src => src.Course))

--- a/HumanResourceProject/Controllers/TeacherController.cs
+++ b/HumanResourceProject/Controllers/TeacherController.cs
@@ -1,0 +1,50 @@
+using Domain.Contracts;
+using DTO;
+using Helpers.Pagination;
+using Microsoft.AspNetCore.Mvc;
+
+namespace PostOfficeProject.Controllers
+{
+    [ApiController]
+    [Route("[controller]")]
+    public class TeacherController : ControllerBase
+    {
+        private readonly ITeacherDomain _teacherDomain;
+
+        public TeacherController(ITeacherDomain teacherDomain)
+        {
+            _teacherDomain = teacherDomain;
+        }
+
+        [HttpPost]
+        [Route("getAll")]
+        public IActionResult GetAll([FromQuery] QueryParameters queryParameters)
+            => Ok(_teacherDomain.GetAllTeachers(queryParameters));
+
+        [HttpGet]
+        [Route("{id}")]
+        public IActionResult GetById([FromRoute] Guid id)
+            => Ok(_teacherDomain.GetTeacherById(id));
+
+        [HttpPost]
+        [Route("add")]
+        public IActionResult AddNew([FromBody] TeacherPostDTO dto)
+        {
+            var result = _teacherDomain.AddNew(dto);
+            return Ok(result);
+        }
+
+        [HttpPatch]
+        [Route("{id}")]
+        public IActionResult Update([FromRoute] Guid id, [FromBody] TeacherPostDTO dto)
+            => Ok(_teacherDomain.Update(id, dto));
+
+        [HttpDelete]
+        [Route("{id}")]
+        public IActionResult Delete([FromRoute] Guid id)
+        {
+            _teacherDomain.Delete(id);
+            return Ok();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- return created teacher with embedded user record
- load user details when listing, retrieving, or updating teachers

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b31dccfcf48332908d0f8105c05e7e