### PR TITLE
Include related entities in schedule retrieval

### DIFF
--- a/DAL/Concrete/ScheduleRepository.cs
+++ b/DAL/Concrete/ScheduleRepository.cs
@@ -1,6 +1,8 @@
 using DAL.Contracts;
 using Entities.Models;
 using Helpers.Pagination;
+using Microsoft.EntityFrameworkCore;
+using System.Linq;
 using static Helpers.Pagination.QueryParameters;
 
 namespace DAL.Concrete
@@ -13,9 +15,29 @@ namespace DAL.Concrete
 
         public PagedList<TblSchedule> GetSchedules(QueryParameters queryParameters)
         {
-            var data = context;
+            var data = context
+                .Include(s => s.Course).ThenInclude(c => c.Department)
+                .Include(s => s.Group).ThenInclude(g => g.Course).ThenInclude(c => c.Department)
+                .Include(s => s.Group).ThenInclude(g => g.AcademicYear)
+                .Include(s => s.Group).ThenInclude(g => g.TblGroupStudents)
+                .Include(s => s.Teacher).ThenInclude(t => t.User)
+                .Include(s => s.Room)
+                .Include(s => s.AcademicYear);
             var filterData = PaginationConfiguration(data, queryParameters.SortField, queryParameters.SortOrder, queryParameters.SearchValue);
             return PagedList<TblSchedule>.ToPagedList(filterData, queryParameters == null ? 1 : queryParameters.CurrentPage, queryParameters == null ? 10 : queryParameters.PageSize);
+        }
+
+        public override TblSchedule GetById(Guid id)
+        {
+            return context
+                .Include(s => s.Course).ThenInclude(c => c.Department)
+                .Include(s => s.Group).ThenInclude(g => g.Course).ThenInclude(c => c.Department)
+                .Include(s => s.Group).ThenInclude(g => g.AcademicYear)
+                .Include(s => s.Group).ThenInclude(g => g.TblGroupStudents)
+                .Include(s => s.Teacher).ThenInclude(t => t.User)
+                .Include(s => s.Room)
+                .Include(s => s.AcademicYear)
+                .FirstOrDefault(s => s.Id == id);
         }
     }
 }

--- a/DTO/ScheduleDTO.cs
+++ b/DTO/ScheduleDTO.cs
@@ -15,6 +15,12 @@ namespace DTO
         public DateTime StartTime { get; set; }
         public DateTime EndTime { get; set; }
         public RoomType ScheduleType { get; set; }
+
+        public GroupDTO Group { get; set; }
+        public CourseDTO Course { get; set; }
+        public TeacherDTO Teacher { get; set; }
+        public RoomDTO Room { get; set; }
+        public AcademicYearDTO AcademicYear { get; set; }
     }
 
     public class SchedulePostDTO

--- a/Domain/Mappings/GeneralProfile.cs
+++ b/Domain/Mappings/GeneralProfile.cs
@@ -90,7 +90,18 @@ namespace Domain.Mappings
             CreateMap<TblGroup, GroupPostDTO>().ReverseMap();
             #endregion
             #region schedules
-            CreateMap<TblSchedule, ScheduleDTO>().ReverseMap();
+            CreateMap<TblSchedule, ScheduleDTO>()
+                .ForMember(dest => dest.Group, opt => opt.MapFrom(src => src.Group))
+                .ForMember(dest => dest.Course, opt => opt.MapFrom(src => src.Course))
+                .ForMember(dest => dest.Teacher, opt => opt.MapFrom(src => src.Teacher))
+                .ForMember(dest => dest.Room, opt => opt.MapFrom(src => src.Room))
+                .ForMember(dest => dest.AcademicYear, opt => opt.MapFrom(src => src.AcademicYear))
+                .ReverseMap()
+                .ForMember(dest => dest.Group, opt => opt.Ignore())
+                .ForMember(dest => dest.Course, opt => opt.Ignore())
+                .ForMember(dest => dest.Teacher, opt => opt.Ignore())
+                .ForMember(dest => dest.Room, opt => opt.Ignore())
+                .ForMember(dest => dest.AcademicYear, opt => opt.Ignore());
             CreateMap<TblSchedule, SchedulePostDTO>().ReverseMap();
             #endregion
         }


### PR DESCRIPTION
## Summary
- Return Group, Course, Teacher, Room, and AcademicYear objects on schedule queries
- Map schedule entity to new DTO properties for related data
- Load related entities in schedule repository for list and single fetches

## Testing
- `dotnet test` *(failed: command not found)*
- `apt-get update` *(failed: repository 403 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b329c0ec0c8332b4ab9ba3d7c9008d