### PR TITLE
Add teacher deletion by user ID

### DIFF
--- a/Domain/Concrete/TeacherDomain.cs
+++ b/Domain/Concrete/TeacherDomain.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using AutoMapper;
 using DAL.Contracts;
 using DAL.UoW;
@@ -43,6 +44,18 @@ namespace Domain.Concrete
             }
             TeacherRepository.Remove(id);
             UserRepository.Remove(teacher.UserId);
+            _unitOfWork.Save();
+        }
+
+        public void DeleteByUserId(Guid userId)
+        {
+            var teacher = TeacherRepository.Find(t => t.UserId == userId).FirstOrDefault();
+            if (teacher == null)
+            {
+                throw new Exception("Teacher not found");
+            }
+            TeacherRepository.Remove(teacher.Id);
+            UserRepository.Remove(userId);
             _unitOfWork.Save();
         }
 

--- a/Domain/Contracts/ITeacherDomain.cs
+++ b/Domain/Contracts/ITeacherDomain.cs
@@ -10,5 +10,6 @@ namespace Domain.Contracts
         TeacherDTO AddNew(TeacherPostDTO teacherPostDTO);
         TeacherDTO Update(Guid id, TeacherPostDTO teacherPostDTO);
         void Delete(Guid id);
+        void DeleteByUserId(Guid userId);
     }
 }

--- a/HumanResourceProject/Controllers/TeacherController.cs
+++ b/HumanResourceProject/Controllers/TeacherController.cs
@@ -46,5 +46,13 @@ namespace PostOfficeProject.Controllers
             _teacherDomain.Delete(id);
             return Ok();
         }
+
+        [HttpDelete]
+        [Route("user/{userId}")]
+        public IActionResult DeleteByUserId([FromRoute] Guid userId)
+        {
+            _teacherDomain.DeleteByUserId(userId);
+            return Ok();
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Allow deleting a teacher using the associated user ID
- Add domain interface and implementation for deleting by user ID
- Expose new controller endpoint `DELETE /Teacher/user/{userId}`

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b3839740e08332a486078ab8b718cf