### PR TITLE
Refactor entities to use Status enum for soft delete

### DIFF
--- a/DAL/Concrete/AcademicYearRepository.cs
+++ b/DAL/Concrete/AcademicYearRepository.cs
@@ -1,5 +1,6 @@
 using DAL.Contracts;
 using Entities.Models;
+using Helpers;
 using Helpers.Pagination;
 using static Helpers.Pagination.QueryParameters;
 
@@ -13,7 +14,7 @@ namespace DAL.Concrete
 
         public PagedList<TblAcademicYear> GetAcademicYears(QueryParameters queryParameters)
         {
-            var data = context.AsQueryable();
+            var data = context.Where(x => x.Status != EntityStatus.Deleted);
             var filtered = PaginationConfiguration(data, queryParameters.SortField, queryParameters.SortOrder, queryParameters.SearchValue);
             return PagedList<TblAcademicYear>.ToPagedList(filtered, queryParameters?.CurrentPage ?? 1, queryParameters?.PageSize ?? 10);
         }

--- a/DAL/Concrete/AttendanceRepository.cs
+++ b/DAL/Concrete/AttendanceRepository.cs
@@ -1,5 +1,6 @@
 using DAL.Contracts;
 using Entities.Models;
+using Helpers;
 using Microsoft.EntityFrameworkCore;
 using System;
 using System.Collections.Generic;
@@ -26,7 +27,8 @@ namespace DAL.Concrete
                 SessionId = sessionId,
                 StudentId = student.Id,
                 CheckInTime = DateTimeOffset.UtcNow,
-                CheckedInBy = "student"
+                CheckedInBy = "student",
+                Status = EntityStatus.Active
             };
             Add(attendance);
             _dbContext.SaveChanges();
@@ -35,7 +37,7 @@ namespace DAL.Concrete
 
         public IEnumerable<TblAttendance> GetByStudent(Guid studentCardId)
         {
-            return _dbContext.TblAttendances.Where(a => a.StudentId == studentCardId).AsNoTracking().ToList();
+            return _dbContext.TblAttendances.Where(a => a.StudentId == studentCardId && a.Status != EntityStatus.Deleted).AsNoTracking().ToList();
         }
     }
 }

--- a/DAL/Concrete/CourseRepository.cs
+++ b/DAL/Concrete/CourseRepository.cs
@@ -1,5 +1,6 @@
 using DAL.Contracts;
 using Entities.Models;
+using Helpers;
 using Helpers.Pagination;
 using Microsoft.EntityFrameworkCore;
 using static Helpers.Pagination.QueryParameters;
@@ -16,7 +17,7 @@ namespace DAL.Concrete
         {
             var data = context
                 .Include(x => x.Department)
-                .Where(x => x.IsActive);
+                .Where(x => x.Status != EntityStatus.Deleted);
             var filterData = PaginationConfiguration(data, queryParameters.SortField, queryParameters.SortOrder, queryParameters.SearchValue);
             return PagedList<TblCourse>.ToPagedList(filterData, queryParameters == null ? 1 : queryParameters.CurrentPage, queryParameters == null ? 10 : queryParameters.PageSize);
         }
@@ -25,7 +26,7 @@ namespace DAL.Concrete
         {
             return context
                 .Include(x => x.Department)
-                .FirstOrDefault(x => x.Id == id);
+                .FirstOrDefault(x => x.Id == id && x.Status != EntityStatus.Deleted);
         }
     }
 }

--- a/DAL/Concrete/DepartmantRepository.cs
+++ b/DAL/Concrete/DepartmantRepository.cs
@@ -1,5 +1,6 @@
-﻿using DAL.Contracts;
+using DAL.Contracts;
 using Entities.Models;
+using Helpers;
 using Helpers.Pagination;
 using Microsoft.EntityFrameworkCore;
 using System;
@@ -18,7 +19,7 @@ namespace DAL.Concrete
         }
         public PagedList<TblDepartment> GetDeparttmants(QueryParameters queryParameters)
         {
-            var data = context.Where(x => x.IsActive);
+            var data = context.Where(x => x.Status != EntityStatus.Deleted);
             var filterData = PaginationConfiguration(data, queryParameters.SortField, queryParameters.SortOrder, queryParameters.SearchValue);
             return PagedList<TblDepartment>.ToPagedList(filterData, queryParameters == null ? 1 : queryParameters.CurrentPage, queryParameters == null ? 10 : queryParameters.PageSize);
 

--- a/DAL/Concrete/GroupRepository.cs
+++ b/DAL/Concrete/GroupRepository.cs
@@ -1,5 +1,6 @@
 using DAL.Contracts;
 using Entities.Models;
+using Helpers;
 using Helpers.Pagination;
 using Microsoft.EntityFrameworkCore;
 using System.Linq;
@@ -16,6 +17,7 @@ namespace DAL.Concrete
         public PagedList<TblGroup> GetGroups(QueryParameters queryParameters)
         {
             var data = context
+                .Where(g => g.Status != EntityStatus.Deleted)
                 .Include(g => g.Course)
                 .Include(g => g.AcademicYear)
                 .Include(g => g.TblGroupStudents);
@@ -30,7 +32,7 @@ namespace DAL.Concrete
                 .Include(g => g.Course)
                 .Include(g => g.AcademicYear)
                 .Include(g => g.TblGroupStudents)
-                .FirstOrDefault(g => g.Id == id);
+                .FirstOrDefault(g => g.Id == id && g.Status != EntityStatus.Deleted);
         }
     }
 }

--- a/DAL/Concrete/RoomRepository.cs
+++ b/DAL/Concrete/RoomRepository.cs
@@ -1,5 +1,6 @@
 using DAL.Contracts;
 using Entities.Models;
+using Helpers;
 using Helpers.Pagination;
 using static Helpers.Pagination.QueryParameters;
 
@@ -13,7 +14,7 @@ namespace DAL.Concrete
 
         public PagedList<TblRoom> GetRooms(QueryParameters queryParameters)
         {
-            var data = context;
+            var data = context.Where(x => x.Status != EntityStatus.Deleted);
             var filterData = PaginationConfiguration(data, queryParameters.SortField, queryParameters.SortOrder, queryParameters.SearchValue);
             return PagedList<TblRoom>.ToPagedList(filterData, queryParameters == null ? 1 : queryParameters.CurrentPage, queryParameters == null ? 10 : queryParameters.PageSize);
         }

--- a/DAL/Concrete/ScheduleRepository.cs
+++ b/DAL/Concrete/ScheduleRepository.cs
@@ -1,5 +1,6 @@
 using DAL.Contracts;
 using Entities.Models;
+using Helpers;
 using Helpers.Pagination;
 using Microsoft.EntityFrameworkCore;
 using System.Linq;
@@ -16,6 +17,7 @@ namespace DAL.Concrete
         public PagedList<TblSchedule> GetSchedules(QueryParameters queryParameters)
         {
             var data = context
+                .Where(s => s.Status != EntityStatus.Deleted)
                 .Include(s => s.Course).ThenInclude(c => c.Department)
                 .Include(s => s.Group).ThenInclude(g => g.Course).ThenInclude(c => c.Department)
                 .Include(s => s.Group).ThenInclude(g => g.AcademicYear)
@@ -37,7 +39,7 @@ namespace DAL.Concrete
                 .Include(s => s.Teacher).ThenInclude(t => t.User)
                 .Include(s => s.Room)
                 .Include(s => s.AcademicYear)
-                .FirstOrDefault(s => s.Id == id);
+                .FirstOrDefault(s => s.Id == id && s.Status != EntityStatus.Deleted);
         }
     }
 }

--- a/DAL/Concrete/StudentCardRepository.cs
+++ b/DAL/Concrete/StudentCardRepository.cs
@@ -20,7 +20,7 @@ namespace DAL.Concrete
 
         public void DisableCardsByUser(Guid userId)
         {
-            var cards = _dbContext.TblStudentCards.Where(x => x.UserId == userId && x.Status != EntityStatus.Disabled).ToList();
+            var cards = _dbContext.TblStudentCards.Where(x => x.UserId == userId && x.Status != EntityStatus.Disabled && x.Status != EntityStatus.Deleted).ToList();
             foreach (var card in cards)
             {
                 card.Status = EntityStatus.Disabled;
@@ -34,6 +34,7 @@ namespace DAL.Concrete
                 .Include(x => x.User)
                 .Include(x => x.Department)
                 .Include(x => x.AcademicYear)
+                .Where(x => x.Status != EntityStatus.Deleted)
                 .AsQueryable();
             if (userId.HasValue)
                 data = data.Where(x => x.UserId == userId.Value);
@@ -51,7 +52,7 @@ namespace DAL.Concrete
                 .Include(x => x.User)
                 .Include(x => x.Department)
                 .Include(x => x.AcademicYear)
-                .FirstOrDefault(x => x.Id == id);
+                .FirstOrDefault(x => x.Id == id && x.Status != EntityStatus.Deleted);
         }
     }
 }

--- a/DAL/Concrete/TeacherRepository.cs
+++ b/DAL/Concrete/TeacherRepository.cs
@@ -2,6 +2,7 @@ using System;
 using System.Linq;
 using DAL.Contracts;
 using Entities.Models;
+using Helpers;
 using Helpers.Pagination;
 using Microsoft.EntityFrameworkCore;
 using static Helpers.Pagination.QueryParameters;
@@ -16,14 +17,14 @@ namespace DAL.Concrete
 
         public PagedList<TblTeacher> GetTeachers(QueryParameters queryParameters)
         {
-            var data = context.Include(t => t.User);
+            var data = context.Include(t => t.User).Where(t => t.Status != EntityStatus.Deleted);
             var filterData = PaginationConfiguration(data, queryParameters.SortField, queryParameters.SortOrder, queryParameters.SearchValue);
             return PagedList<TblTeacher>.ToPagedList(filterData, queryParameters == null ? 1 : queryParameters.CurrentPage, queryParameters == null ? 10 : queryParameters.PageSize);
         }
 
         public override TblTeacher GetById(Guid id)
         {
-            return context.Include(t => t.User).FirstOrDefault(t => t.Id == id);
+            return context.Include(t => t.User).FirstOrDefault(t => t.Id == id && t.Status != EntityStatus.Deleted);
         }
     }
 }

--- a/DAL/Concrete/UserRepository.cs
+++ b/DAL/Concrete/UserRepository.cs
@@ -21,12 +21,12 @@ namespace DAL.Concrete
 
         public TblUser CheckIfUsernamExist(string userName)
         {
-            return context.Include(x=>x.UserType).FirstOrDefault(x => x.Status == EntityStatus.Active && x.Username.ToLower() == userName.ToLower());
+            return context.Include(x=>x.UserType).FirstOrDefault(x => x.Status != EntityStatus.Deleted && x.Username.ToLower() == userName.ToLower());
         }
 
         public PagedList<TblUser> GetAllUsers(QueryParameters queryParameters)
         {
-            var data = context.Where(x => x.Status == EntityStatus.Active);
+            var data = context.Where(x => x.Status != EntityStatus.Deleted);
             var filterData = PaginationConfiguration(data, queryParameters.SortField, queryParameters.SortOrder, queryParameters.SearchValue);
             return PagedList<TblUser>.ToPagedList(filterData, queryParameters == null ? 1 : queryParameters.CurrentPage, queryParameters == null ? 10 : queryParameters.PageSize);
 
@@ -34,7 +34,7 @@ namespace DAL.Concrete
 
         public PagedList<TblUser> GetUsersByTypeIds(IEnumerable<Guid> userTypeIds, QueryParameters queryParameters)
         {
-            var data = context.Where(x => x.Status == EntityStatus.Active && userTypeIds.Contains(x.UserTypeId));
+            var data = context.Where(x => x.Status != EntityStatus.Deleted && userTypeIds.Contains(x.UserTypeId));
             var filterData = PaginationConfiguration(data, queryParameters.SortField, queryParameters.SortOrder, queryParameters.SearchValue);
             return PagedList<TblUser>.ToPagedList(filterData, queryParameters.CurrentPage, queryParameters.PageSize);
         }

--- a/DTO/AcademicYearDTO.cs
+++ b/DTO/AcademicYearDTO.cs
@@ -1,4 +1,5 @@
 using System;
+using Helpers;
 
 namespace DTO
 {
@@ -7,13 +8,13 @@ namespace DTO
         public Guid Id { get; set; }
         public string Year { get; set; } = null!;
         public int StartingYear { get; set; }
-        public bool? IsActive { get; set; }
+        public EntityStatus Status { get; set; }
     }
 
     public class AcademicYearPostDTO
     {
-        public int StartingYear { get; set; } 
+        public int StartingYear { get; set; }
         public string? Year { get; set; }
-        public bool? IsActive { get; set; }
+        public EntityStatus? Status { get; set; }
     }
 }

--- a/DTO/AttendanceDTO.cs
+++ b/DTO/AttendanceDTO.cs
@@ -1,4 +1,5 @@
 using System;
+using Helpers;
 
 namespace DTO
 {
@@ -9,6 +10,7 @@ namespace DTO
         public Guid StudentId { get; set; }
         public DateTimeOffset CheckInTime { get; set; }
         public string CheckedInBy { get; set; } = null!;
+        public EntityStatus Status { get; set; }
     }
 
     public class AttendanceCheckInDTO

--- a/DTO/CourseDTO.cs
+++ b/DTO/CourseDTO.cs
@@ -1,8 +1,9 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Helpers;
 
 namespace DTO
 {
@@ -11,7 +12,7 @@ namespace DTO
         public Guid Id { get; set; }
         public string Name { get; set; } = null!;
         public DepartmantDTO Departmant { get; set; }
-        public bool IsActive { get; set; }
+        public EntityStatus Status { get; set; }
         public int Credits { get; set; }
         public int? TotalHours { get; set; }
     }
@@ -19,7 +20,7 @@ namespace DTO
     {
         public string? Name { get; set; } = null!;
         public Guid? DepartmantId{ get; set; }
-        public bool? IsActive { get; set; }
+        public EntityStatus? Status { get; set; }
         public int? Credits { get; set; }
         public int? TotalHours { get; set; }
     }

--- a/DTO/DepartmantDTO.cs
+++ b/DTO/DepartmantDTO.cs
@@ -1,8 +1,9 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Helpers;
 
 namespace DTO
 {
@@ -13,7 +14,7 @@ namespace DTO
         public string Abbreviation { get; set; }
         public DateTimeOffset? CreatedDate { get; set; }
         public string? Description { get; set; }
-        public bool isActive { get; set; }
+        public EntityStatus Status { get; set; }
     }
     public class DepartmantPostDTO
     {

--- a/DTO/GroupDTO.cs
+++ b/DTO/GroupDTO.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using Helpers;
 
 namespace DTO
 {
@@ -13,6 +14,7 @@ namespace DTO
         public AcademicYearDTO AcademicYear { get; set; }
         public List<Guid> StudentIds { get; set; }
         public int StudentsLength { get; set; }
+        public EntityStatus Status { get; set; }
     }
 
     public class GroupPostDTO
@@ -21,5 +23,6 @@ namespace DTO
         public Guid? CourseId { get; set; }
         public Guid? AcademicYearId { get; set; }
         public List<Guid>? StudentIds { get; set; }
+        public EntityStatus? Status { get; set; }
     }
 }

--- a/DTO/PostOfficeDTO/PostOfficeDTO.cs
+++ b/DTO/PostOfficeDTO/PostOfficeDTO.cs
@@ -1,8 +1,9 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Helpers;
 
 namespace DTO.PostOfficeDTO
 {
@@ -12,7 +13,7 @@ namespace DTO.PostOfficeDTO
         public string? Name { get; set; }
         public string? address { get; set; }
         public string? postalCode { get; set; }
-        public bool? IsActive { get; set; }
+        public EntityStatus Status { get; set; }
     }
     public class PostOfficePostDTO
     {

--- a/DTO/RoomDTO.cs
+++ b/DTO/RoomDTO.cs
@@ -9,6 +9,7 @@ namespace DTO
         public string Name { get; set; }
         public RoomType RoomType { get; set; }
         public int? SeatsNumber { get; set; }
+        public EntityStatus Status { get; set; }
     }
 
     public class RoomPostDTO
@@ -16,5 +17,6 @@ namespace DTO
         public string? Name { get; set; }
         public RoomType? RoomType { get; set; }
         public int? SeatsNumber { get; set; }
+        public EntityStatus? Status { get; set; }
     }
 }

--- a/DTO/ScheduleDTO.cs
+++ b/DTO/ScheduleDTO.cs
@@ -15,6 +15,7 @@ namespace DTO
         public DateTimeOffset StartTime { get; set; }
         public DateTimeOffset EndTime { get; set; }
         public RoomType ScheduleType { get; set; }
+        public EntityStatus Status { get; set; }
 
         public GroupDTO Group { get; set; }
         public CourseDTO Course { get; set; }
@@ -34,5 +35,6 @@ namespace DTO
         public DateTimeOffset? StartTime { get; set; }
         public DateTimeOffset? EndTime { get; set; }
         public RoomType? ScheduleType { get; set; }
+        public EntityStatus? Status { get; set; }
     }
 }

--- a/DTO/TeacherDTO.cs
+++ b/DTO/TeacherDTO.cs
@@ -1,5 +1,6 @@
 using System;
 using DTO.UserDTO;
+using Helpers;
 
 namespace DTO
 {
@@ -8,10 +9,12 @@ namespace DTO
         public Guid Id { get; set; }
         public Guid UserId { get; set; }
         public UserSimpleDTO User { get; set; } = null!;
+        public EntityStatus Status { get; set; }
     }
 
     public class TeacherPostDTO
     {
         public Guid? UserId { get; set; }
+        public EntityStatus? Status { get; set; }
     }
 }

--- a/DTO/UserTypeDTO/UserTypeDTO.cs
+++ b/DTO/UserTypeDTO/UserTypeDTO.cs
@@ -1,21 +1,22 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Helpers;
 
 namespace DTO.UserTypeDTO
 {
     public class UserTypeDTO
     {
         public Guid Id { get; set; }
-        public bool IsActive { get; set; }
+        public EntityStatus Status { get; set; }
         public string? Name { get; set; }
     }
     public class UserTypeGetDTO
     {
         public Guid Id { get; set; }
-        public bool IsActive { get; set; }
+        public EntityStatus Status { get; set; }
         public string? Name { get; set; }
     }
 

--- a/Domain/Concrete/AcademicYearDomain.cs
+++ b/Domain/Concrete/AcademicYearDomain.cs
@@ -4,6 +4,7 @@ using DAL.UoW;
 using Domain.Contracts;
 using DTO;
 using Entities.Models;
+using Helpers;
 using Helpers.Pagination;
 using Microsoft.AspNetCore.Http;
 
@@ -21,6 +22,7 @@ namespace Domain.Concrete
         {
             var entity = _mapper.Map<TblAcademicYear>(academicYearPostDTO);
             entity.Id = Guid.NewGuid();
+            entity.Status = academicYearPostDTO.Status ?? EntityStatus.Active;
             AcademicYearRepository.Add(entity);
             _unitOfWork.Save();
         }
@@ -51,8 +53,8 @@ namespace Domain.Concrete
             }
             if (!string.IsNullOrWhiteSpace(academicYearPostDTO.Year))
                 entity.Year = academicYearPostDTO.Year;
-            if (academicYearPostDTO.IsActive.HasValue)
-                entity.IsActive = academicYearPostDTO.IsActive;
+            if (academicYearPostDTO.Status.HasValue)
+                entity.Status = academicYearPostDTO.Status.Value;
             AcademicYearRepository.SetModified(entity);
             _unitOfWork.Save();
             return _mapper.Map<AcademicYearDTO>(entity);

--- a/Domain/Concrete/CourseDomain.cs
+++ b/Domain/Concrete/CourseDomain.cs
@@ -4,6 +4,7 @@ using DAL.UoW;
 using Domain.Contracts;
 using DTO;
 using Entities.Models;
+using Helpers;
 using Helpers.Pagination;
 using Microsoft.AspNetCore.Http;
 
@@ -21,8 +22,7 @@ namespace Domain.Concrete
         {
             var entity = _mapper.Map<TblCourse>(course);
             entity.Id = Guid.NewGuid();
-            if (!course.IsActive.HasValue)
-                entity.IsActive = true;
+            entity.Status = course.Status ?? EntityStatus.Active;
             CourseRepository.Add(entity);
             _unitOfWork.Save();
         }
@@ -63,8 +63,8 @@ namespace Domain.Concrete
                 entity.Credits = course.Credits.Value;
             if (course.TotalHours.HasValue)
                 entity.TotalHours = course.TotalHours.Value;
-            if (course.IsActive.HasValue)
-                entity.IsActive = course.IsActive.Value;
+            if (course.Status.HasValue)
+                entity.Status = course.Status.Value;
             if (course.DepartmantId.HasValue)
                 entity.DepartmentId = course.DepartmantId.Value;
             CourseRepository.SetModified(entity);

--- a/Domain/Concrete/DepartmantDomain.cs
+++ b/Domain/Concrete/DepartmantDomain.cs
@@ -1,4 +1,4 @@
-﻿using AutoMapper;
+using AutoMapper;
 using DAL.Contracts;
 using DAL.UoW;
 using Domain.Contracts;
@@ -6,6 +6,7 @@ using DTO;
 using DTO.UserDTO;
 using DTO.UserTypeDTO;
 using Entities.Models;
+using Helpers;
 using Helpers.Pagination;
 using Microsoft.AspNetCore.Http;
 using System;
@@ -29,7 +30,7 @@ namespace Domain.Concrete
             try
             {
                 var mapped = _mapper.Map<TblCourse>(course);
-                mapped.IsActive = true;
+                mapped.Status = EntityStatus.Active;
                 mapped.DepartmentId = departmantId;
                 mapped.Id = Guid.NewGuid();
                 CourseRepository.Add(mapped);
@@ -48,7 +49,7 @@ namespace Domain.Concrete
             {
                 var mapper = _mapper.Map<TblDepartment>(departmantPostDTO);
                 mapper.CreatedDate = DateTimeOffset.Now;
-                mapper.IsActive = true;
+                mapper.Status = EntityStatus.Active;
                 mapper.Id = Guid.NewGuid();
                 DepartmantRepository.Add(mapper);
                 _unitOfWork.Save();
@@ -127,8 +128,8 @@ namespace Domain.Concrete
                 }
                 if(course.TotalHours.HasValue)
                     courseEntity.TotalHours = course.TotalHours.Value;
-                if(course.IsActive.HasValue)
-                    courseEntity.IsActive = course.IsActive.Value;
+                if(course.Status.HasValue)
+                    courseEntity.Status = course.Status.Value;
                 if (!string.IsNullOrWhiteSpace(course.Name))
                     courseEntity.Name = course.Name;
                 if (course.Credits.HasValue)

--- a/Domain/Concrete/GroupDomain.cs
+++ b/Domain/Concrete/GroupDomain.cs
@@ -7,6 +7,7 @@ using DAL.UoW;
 using Domain.Contracts;
 using DTO;
 using Entities.Models;
+using Helpers;
 using Helpers.Pagination;
 using Microsoft.AspNetCore.Http;
 
@@ -25,6 +26,7 @@ namespace Domain.Concrete
         {
             var entity = _mapper.Map<TblGroup>(group);
             entity.Id = Guid.NewGuid();
+            entity.Status = group.Status ?? EntityStatus.Active;
             GroupRepository.Add(entity);
             if (group.StudentIds != null && group.StudentIds.Any())
             {
@@ -88,6 +90,8 @@ namespace Domain.Concrete
                 entity.CourseId = group.CourseId.Value;
             if (group.AcademicYearId.HasValue)
                 entity.AcademicYearId = group.AcademicYearId.Value;
+            if (group.Status.HasValue)
+                entity.Status = group.Status.Value;
             GroupRepository.SetModified(entity);
             _unitOfWork.Save();
             return _mapper.Map<GroupDTO>(entity);

--- a/Domain/Concrete/RoomDomain.cs
+++ b/Domain/Concrete/RoomDomain.cs
@@ -4,6 +4,7 @@ using DAL.UoW;
 using Domain.Contracts;
 using DTO;
 using Entities.Models;
+using Helpers;
 using Helpers.Pagination;
 using Microsoft.AspNetCore.Http;
 
@@ -21,6 +22,7 @@ namespace Domain.Concrete
         {
             var entity = _mapper.Map<TblRoom>(roomPostDTO);
             entity.Id = Guid.NewGuid();
+            entity.Status = roomPostDTO.Status ?? EntityStatus.Active;
             RoomRepository.Add(entity);
             _unitOfWork.Save();
         }
@@ -61,6 +63,8 @@ namespace Domain.Concrete
                 entity.RoomType = roomPostDTO.RoomType.Value;
             if (roomPostDTO.SeatsNumber.HasValue)
                 entity.SeatsNumber = roomPostDTO.SeatsNumber.Value;
+            if (roomPostDTO.Status.HasValue)
+                entity.Status = roomPostDTO.Status.Value;
             RoomRepository.SetModified(entity);
             _unitOfWork.Save();
             return _mapper.Map<RoomDTO>(entity);

--- a/Domain/Concrete/ScheduleDomain.cs
+++ b/Domain/Concrete/ScheduleDomain.cs
@@ -4,6 +4,7 @@ using DAL.UoW;
 using Domain.Contracts;
 using DTO;
 using Entities.Models;
+using Helpers;
 using Helpers.Pagination;
 using Microsoft.AspNetCore.Http;
 
@@ -21,6 +22,7 @@ namespace Domain.Concrete
         {
             var entity = _mapper.Map<TblSchedule>(schedule);
             entity.Id = Guid.NewGuid();
+            entity.Status = schedule.Status ?? EntityStatus.Active;
             ScheduleRepository.Add(entity);
             _unitOfWork.Save();
         }
@@ -73,6 +75,8 @@ namespace Domain.Concrete
                 entity.EndTime = schedule.EndTime.Value;
             if (schedule.ScheduleType.HasValue)
                 entity.ScheduleType = schedule.ScheduleType.Value;
+            if (schedule.Status.HasValue)
+                entity.Status = schedule.Status.Value;
             ScheduleRepository.SetModified(entity);
             _unitOfWork.Save();
             return _mapper.Map<ScheduleDTO>(entity);

--- a/Domain/Concrete/TeacherDomain.cs
+++ b/Domain/Concrete/TeacherDomain.cs
@@ -6,6 +6,7 @@ using DAL.UoW;
 using Domain.Contracts;
 using DTO;
 using Entities.Models;
+using Helpers;
 using Helpers.Pagination;
 using Microsoft.AspNetCore.Http;
 
@@ -27,6 +28,7 @@ namespace Domain.Concrete
 
             var entity = _mapper.Map<TblTeacher>(teacherPostDTO);
             entity.Id = Guid.NewGuid();
+            entity.Status = teacherPostDTO.Status ?? EntityStatus.Active;
             TeacherRepository.Add(entity);
             _unitOfWork.Save();
 
@@ -72,6 +74,8 @@ namespace Domain.Concrete
             }
             if (teacherPostDTO.UserId.HasValue)
                 entity.UserId = teacherPostDTO.UserId.Value;
+            if (teacherPostDTO.Status.HasValue)
+                entity.Status = teacherPostDTO.Status.Value;
             TeacherRepository.SetModified(entity);
             _unitOfWork.Save();
 

--- a/Domain/Concrete/UserDomain.cs
+++ b/Domain/Concrete/UserDomain.cs
@@ -1,4 +1,4 @@
-﻿using AutoMapper;
+using AutoMapper;
 using DAL.Contracts;
 using DAL.UoW;
 using Domain.Contracts;
@@ -264,7 +264,7 @@ namespace Domain.Concrete
             {
                 var mapper = _mapper.Map<TblUserType>(userTypePostDTO);
                 mapper.Id = Guid.NewGuid();
-                mapper.IsActive = true;
+                mapper.Status = EntityStatus.Active;
                 UserTypeRepository.Add(mapper);
                 _unitOfWork.Save();
             }

--- a/Entities/Models/SchoolAdministrationContext.cs
+++ b/Entities/Models/SchoolAdministrationContext.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata;
@@ -62,6 +62,8 @@ namespace Entities.Models
 
                 entity.Property(e => e.SentAt).HasColumnType("datetime");
 
+                entity.Property(e => e.Status).HasDefaultValueSql("((1))");
+
                 entity.HasOne(d => d.Course)
                     .WithMany(p => p.TblAbsenceWarnings)
                     .HasForeignKey(d => d.CourseId)
@@ -84,7 +86,7 @@ namespace Entities.Models
 
                 entity.Property(e => e.Id).HasDefaultValueSql("(newid())");
 
-                entity.Property(e => e.IsActive).HasDefaultValueSql("((1))");
+                entity.Property(e => e.Status).HasDefaultValueSql("((1))");
 
                 entity.Property(e => e.Year).HasMaxLength(20);
             });
@@ -103,6 +105,8 @@ namespace Entities.Models
                     .HasColumnType("datetime");
 
                 entity.Property(e => e.CheckedInBy).HasMaxLength(50);
+
+                entity.Property(e => e.Status).HasDefaultValueSql("((1))");
 
                 entity.HasOne(d => d.Session)
                     .WithMany(p => p.TblAttendances)
@@ -123,7 +127,7 @@ namespace Entities.Models
 
                 entity.Property(e => e.Id).HasDefaultValueSql("(newid())");
 
-                entity.Property(e => e.IsActive).HasDefaultValueSql("((1))");
+                entity.Property(e => e.Status).HasDefaultValueSql("((1))");
 
                 entity.Property(e => e.Name).HasMaxLength(100);
 
@@ -142,7 +146,7 @@ namespace Entities.Models
 
                 entity.Property(e => e.Id).HasDefaultValueSql("(newid())");
 
-                entity.Property(e => e.IsActive).HasDefaultValueSql("((1))");
+                entity.Property(e => e.Status).HasDefaultValueSql("((1))");
 
                 entity.Property(e => e.Name).HasMaxLength(100);
 
@@ -157,6 +161,8 @@ namespace Entities.Models
                 entity.Property(e => e.Id).HasDefaultValueSql("(newid())");
 
                 entity.Property(e => e.Name).HasMaxLength(50);
+
+                entity.Property(e => e.Status).HasDefaultValueSql("((1))");
 
                 entity.HasOne(d => d.AcademicYear)
                     .WithMany(p => p.TblGroups)
@@ -203,6 +209,8 @@ namespace Entities.Models
                 entity.Property(e => e.Id).HasDefaultValueSql("(newid())");
 
                 entity.Property(e => e.Name).HasMaxLength(50);
+
+                entity.Property(e => e.Status).HasDefaultValueSql("((1))");
             });
 
             modelBuilder.Entity<TblSchedule>(entity =>
@@ -210,6 +218,8 @@ namespace Entities.Models
                 entity.ToTable("tblSchedule");
 
                 entity.Property(e => e.Id).HasDefaultValueSql("(newid())");
+
+                entity.Property(e => e.Status).HasDefaultValueSql("((1))");
 
                 entity.HasOne(d => d.Course)
                     .WithMany(p => p.TblSchedules)
@@ -264,6 +274,8 @@ namespace Entities.Models
                 entity.Property(e => e.OtpcreatedAt)
                     .HasColumnType("datetime")
                     .HasColumnName("OTPCreatedAt");
+
+                entity.Property(e => e.Status).HasDefaultValueSql("((1))");
 
                 entity.HasOne(d => d.Schedule)
                     .WithMany(p => p.TblSessions)
@@ -321,6 +333,8 @@ namespace Entities.Models
                     .IsUnique();
 
                 entity.Property(e => e.Id).HasDefaultValueSql("(newid())");
+
+                entity.Property(e => e.Status).HasDefaultValueSql("((1))");
 
                 entity.HasOne(d => d.User)
                     .WithOne(p => p.TblTeacher)
@@ -384,6 +398,8 @@ namespace Entities.Models
                 entity.Property(e => e.Name)
                     .HasMaxLength(255)
                     .IsUnicode(false);
+
+                entity.Property(e => e.Status).HasDefaultValueSql("((1))");
             });
 
             OnModelCreatingPartial(modelBuilder);

--- a/Entities/Models/TblAbsenceWarning.cs
+++ b/Entities/Models/TblAbsenceWarning.cs
@@ -1,5 +1,6 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
+using Helpers;
 
 namespace Entities.Models
 {
@@ -10,6 +11,7 @@ namespace Entities.Models
         public Guid CourseId { get; set; }
         public double Percentage { get; set; }
         public DateTime SentAt { get; set; }
+        public EntityStatus Status { get; set; }
 
         public virtual TblCourse Course { get; set; } = null!;
         public virtual TblStudentCard Student { get; set; } = null!;

--- a/Entities/Models/TblAcademicYear.cs
+++ b/Entities/Models/TblAcademicYear.cs
@@ -1,5 +1,6 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
+using Helpers;
 
 namespace Entities.Models
 {
@@ -13,9 +14,9 @@ namespace Entities.Models
         }
 
         public Guid Id { get; set; }
-        public int StartingYear { get; set; } 
+        public int StartingYear { get; set; }
         public string Year { get; set; } = null!;
-        public bool? IsActive { get; set; }
+        public EntityStatus Status { get; set; }
 
         public virtual ICollection<TblGroup> TblGroups { get; set; }
         public virtual ICollection<TblStudentCard> TblStudentCards { get; set; }

--- a/Entities/Models/TblAttendance.cs
+++ b/Entities/Models/TblAttendance.cs
@@ -1,5 +1,6 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
+using Helpers;
 
 namespace Entities.Models
 {
@@ -10,6 +11,7 @@ namespace Entities.Models
         public Guid StudentId { get; set; }
         public DateTimeOffset CheckInTime { get; set; }
         public string CheckedInBy { get; set; } = null!;
+        public EntityStatus Status { get; set; }
 
         public virtual TblSession Session { get; set; } = null!;
         public virtual TblStudentCard Student { get; set; } = null!;

--- a/Entities/Models/TblCourse.cs
+++ b/Entities/Models/TblCourse.cs
@@ -1,5 +1,6 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
+using Helpers;
 
 namespace Entities.Models
 {
@@ -15,7 +16,7 @@ namespace Entities.Models
         public Guid Id { get; set; }
         public string Name { get; set; } = null!;
         public Guid DepartmentId { get; set; }
-        public bool IsActive { get; set; }
+        public EntityStatus Status { get; set; }
         public int Credits { get; set; }
         public int? TotalHours { get; set; }
 

--- a/Entities/Models/TblDepartment.cs
+++ b/Entities/Models/TblDepartment.cs
@@ -1,5 +1,6 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
+using Helpers;
 
 namespace Entities.Models
 {
@@ -16,7 +17,7 @@ namespace Entities.Models
         public string Abbreviation { get; set; } = null!;
         public string? Description { get; set; } = null;
         public DateTimeOffset? CreatedDate { get; set; }
-        public bool IsActive { get; set; }
+        public EntityStatus Status { get; set; }
 
         public virtual ICollection<TblCourse> TblCourses { get; set; }
         public virtual ICollection<TblStudentCard> TblStudentCards { get; set; }

--- a/Entities/Models/TblGroup.cs
+++ b/Entities/Models/TblGroup.cs
@@ -1,5 +1,6 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
+using Helpers;
 
 namespace Entities.Models
 {
@@ -15,6 +16,7 @@ namespace Entities.Models
         public string Name { get; set; } = null!;
         public Guid CourseId { get; set; }
         public Guid AcademicYearId { get; set; }
+        public EntityStatus Status { get; set; }
 
         public virtual TblAcademicYear AcademicYear { get; set; } = null!;
         public virtual TblCourse Course { get; set; } = null!;

--- a/Entities/Models/TblRoom.cs
+++ b/Entities/Models/TblRoom.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using Helpers;
 
@@ -15,6 +15,7 @@ namespace Entities.Models
         public string Name { get; set; } = null!;
         public RoomType RoomType { get; set; }
         public int? SeatsNumber { get; set; }
+        public EntityStatus Status { get; set; }
 
         public virtual ICollection<TblSchedule> TblSchedules { get; set; }
     }

--- a/Entities/Models/TblSchedule.cs
+++ b/Entities/Models/TblSchedule.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using Helpers;
 
@@ -21,6 +21,7 @@ namespace Entities.Models
         public DateTimeOffset StartTime { get; set; }
         public DateTimeOffset EndTime { get; set; }
         public RoomType ScheduleType { get; set; }
+        public EntityStatus Status { get; set; }
 
         public virtual TblCourse Course { get; set; } = null!;
         public virtual TblGroup Group { get; set; } = null!;

--- a/Entities/Models/TblSession.cs
+++ b/Entities/Models/TblSession.cs
@@ -1,5 +1,6 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
+using Helpers;
 
 namespace Entities.Models
 {
@@ -16,6 +17,7 @@ namespace Entities.Models
         public bool? IsOpen { get; set; }
         public string? Otp { get; set; }
         public DateTime? OtpcreatedAt { get; set; }
+        public EntityStatus Status { get; set; }
 
         public virtual TblSchedule Schedule { get; set; } = null!;
         public virtual ICollection<TblAttendance> TblAttendances { get; set; }

--- a/Entities/Models/TblTeacher.cs
+++ b/Entities/Models/TblTeacher.cs
@@ -1,5 +1,6 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
+using Helpers;
 
 namespace Entities.Models
 {
@@ -12,6 +13,7 @@ namespace Entities.Models
 
         public Guid Id { get; set; }
         public Guid UserId { get; set; }
+        public EntityStatus Status { get; set; }
 
         public virtual TblUser User { get; set; } = null!;
         public virtual ICollection<TblSchedule> TblSchedules { get; set; }

--- a/Entities/Models/TblUserType.cs
+++ b/Entities/Models/TblUserType.cs
@@ -1,5 +1,6 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
+using Helpers;
 
 namespace Entities.Models
 {
@@ -12,7 +13,7 @@ namespace Entities.Models
 
         public Guid Id { get; set; }
         public string? Name { get; set; }
-        public bool? IsActive { get; set; }
+        public EntityStatus Status { get; set; }
 
         public virtual ICollection<TblUser> TblUsers { get; set; }
     }

--- a/Helpers/Enumerations/Enum.cs
+++ b/Helpers/Enumerations/Enum.cs
@@ -32,7 +32,8 @@ namespace Helpers
     {
         Active = 1,
         Inactive = 2,
-        Disabled = 3
+        Disabled = 3,
+        Deleted = 4
     }
     public enum DayOfWeek
     {


### PR DESCRIPTION
## Summary
- replace legacy IsActive flags with EntityStatus on all primary models
- filter repositories by Status to skip soft-deleted records
- default new entities to Active status in EF context

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b3831d512c8332a3216ec6db4043f0