### PR TITLE
Handle null cases in schedule listing

### DIFF
--- a/Domain/Concrete/ScheduleDomain.cs
+++ b/Domain/Concrete/ScheduleDomain.cs
@@ -35,8 +35,16 @@ namespace Domain.Concrete
 
         public Pagination<ScheduleDTO> GetAllSchedules(QueryParameters queryParameters)
         {
+            // Ensure the query parameters are not null to avoid null reference issues
+            queryParameters ??= new QueryParameters();
+
             var schedules = ScheduleRepository.GetSchedules(queryParameters);
-            var paginatedData = Pagination<ScheduleDTO>.ToPagedList(schedules, _mapper.Map<List<ScheduleDTO>>);
+
+            // Map the result to DTOs and guarantee that the Data list is never null
+            var paginatedData = Pagination<ScheduleDTO>.ToPagedList(
+                schedules,
+                src => _mapper.Map<List<ScheduleDTO>>(src) ?? new List<ScheduleDTO>());
+
             return paginatedData;
         }
 


### PR DESCRIPTION
## Summary
- prevent null reference when schedule list filters are missing
- ensure schedule listing always returns a non-null data collection

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b38bd196108332973c1b4f224aad7e