### PR TITLE
Add filtering support for group and schedule retrieval

### DIFF
--- a/DAL/Concrete/GroupRepository.cs
+++ b/DAL/Concrete/GroupRepository.cs
@@ -14,13 +14,18 @@ namespace DAL.Concrete
         {
         }
 
-        public PagedList<TblGroup> GetGroups(QueryParameters queryParameters)
+        public PagedList<TblGroup> GetGroups(QueryParameters queryParameters, Guid? studentId = null)
         {
             var data = context
                 .Where(g => g.Status != EntityStatus.Deleted)
                 .Include(g => g.Course)
                 .Include(g => g.AcademicYear)
                 .Include(g => g.TblGroupStudents);
+
+            if (studentId.HasValue)
+            {
+                data = data.Where(g => g.TblGroupStudents.Any(gs => gs.StudentId == studentId.Value));
+            }
 
             var filterData = PaginationConfiguration(data, queryParameters.SortField, queryParameters.SortOrder, queryParameters.SearchValue);
             return PagedList<TblGroup>.ToPagedList(filterData, queryParameters == null ? 1 : queryParameters.CurrentPage, queryParameters == null ? 10 : queryParameters.PageSize);

--- a/DAL/Concrete/ScheduleRepository.cs
+++ b/DAL/Concrete/ScheduleRepository.cs
@@ -1,3 +1,4 @@
+using System;
 using DAL.Contracts;
 using Entities.Models;
 using Helpers;
@@ -14,7 +15,7 @@ namespace DAL.Concrete
         {
         }
 
-        public PagedList<TblSchedule> GetSchedules(QueryParameters queryParameters)
+        public PagedList<TblSchedule> GetSchedules(QueryParameters queryParameters, Guid? groupId = null, Guid? studentId = null, Guid? teacherId = null)
         {
             var data = context
                 .Where(s => s.Status != EntityStatus.Deleted)
@@ -25,6 +26,21 @@ namespace DAL.Concrete
                 .Include(s => s.Teacher).ThenInclude(t => t.User)
                 .Include(s => s.Room)
                 .Include(s => s.AcademicYear);
+
+            if (groupId.HasValue)
+            {
+                data = data.Where(s => s.GroupId == groupId.Value);
+            }
+
+            if (teacherId.HasValue)
+            {
+                data = data.Where(s => s.TeacherId == teacherId.Value);
+            }
+
+            if (studentId.HasValue)
+            {
+                data = data.Where(s => s.Group.TblGroupStudents.Any(gs => gs.StudentId == studentId.Value));
+            }
 
             // Safely handle null query parameters to avoid null reference exceptions
             var filterData = PaginationConfiguration(

--- a/DAL/Contracts/IGroupRepository.cs
+++ b/DAL/Contracts/IGroupRepository.cs
@@ -6,6 +6,6 @@ namespace DAL.Contracts
 {
     public interface IGroupRepository : IRepository<TblGroup, Guid>
     {
-        PagedList<TblGroup> GetGroups(QueryParameters queryParameters);
+        PagedList<TblGroup> GetGroups(QueryParameters queryParameters, Guid? studentId = null);
     }
 }

--- a/DAL/Contracts/IScheduleRepository.cs
+++ b/DAL/Contracts/IScheduleRepository.cs
@@ -6,6 +6,6 @@ namespace DAL.Contracts
 {
     public interface IScheduleRepository : IRepository<TblSchedule, Guid>
     {
-        PagedList<TblSchedule> GetSchedules(QueryParameters queryParameters);
+        PagedList<TblSchedule> GetSchedules(QueryParameters queryParameters, Guid? groupId = null, Guid? studentId = null, Guid? teacherId = null);
     }
 }

--- a/Domain/Concrete/GroupDomain.cs
+++ b/Domain/Concrete/GroupDomain.cs
@@ -60,9 +60,9 @@ namespace Domain.Concrete
             _unitOfWork.Save();
         }
 
-        public Pagination<GroupDTO> GetAllGroups(QueryParameters queryParameters)
+        public Pagination<GroupDTO> GetAllGroups(QueryParameters queryParameters, Guid? studentId)
         {
-            var groups = GroupRepository.GetGroups(queryParameters);
+            var groups = GroupRepository.GetGroups(queryParameters, studentId);
             var paginatedData = Pagination<GroupDTO>.ToPagedList(groups, _mapper.Map<List<GroupDTO>>);
             return paginatedData;
         }

--- a/Domain/Concrete/ScheduleDomain.cs
+++ b/Domain/Concrete/ScheduleDomain.cs
@@ -33,12 +33,12 @@ namespace Domain.Concrete
             _unitOfWork.Save();
         }
 
-        public Pagination<ScheduleDTO> GetAllSchedules(QueryParameters queryParameters)
+        public Pagination<ScheduleDTO> GetAllSchedules(QueryParameters queryParameters, Guid? groupId, Guid? studentId, Guid? teacherId)
         {
             // Ensure the query parameters are not null to avoid null reference issues
             queryParameters ??= new QueryParameters();
 
-            var schedules = ScheduleRepository.GetSchedules(queryParameters);
+            var schedules = ScheduleRepository.GetSchedules(queryParameters, groupId, studentId, teacherId);
 
             // Map the result to DTOs and guarantee that the Data list is never null
             var paginatedData = Pagination<ScheduleDTO>.ToPagedList(

--- a/Domain/Contracts/IGroupDomain.cs
+++ b/Domain/Contracts/IGroupDomain.cs
@@ -7,7 +7,7 @@ namespace Domain.Contracts
 {
     public interface IGroupDomain
     {
-        Pagination<GroupDTO> GetAllGroups(QueryParameters queryParameters);
+        Pagination<GroupDTO> GetAllGroups(QueryParameters queryParameters, Guid? studentId);
         GroupDTO GetGroupById(Guid id);
         void AddNew(GroupPostDTO group);
         GroupDTO Update(Guid id, GroupPostDTO group);

--- a/Domain/Contracts/IScheduleDomain.cs
+++ b/Domain/Contracts/IScheduleDomain.cs
@@ -1,3 +1,4 @@
+using System;
 using DTO;
 using Helpers.Pagination;
 
@@ -5,7 +6,7 @@ namespace Domain.Contracts
 {
     public interface IScheduleDomain
     {
-        Pagination<ScheduleDTO> GetAllSchedules(QueryParameters queryParameters);
+        Pagination<ScheduleDTO> GetAllSchedules(QueryParameters queryParameters, Guid? groupId, Guid? studentId, Guid? teacherId);
         ScheduleDTO GetScheduleById(Guid id);
         void AddNew(SchedulePostDTO schedule);
         ScheduleDTO Update(Guid id, SchedulePostDTO schedule);

--- a/HumanResourceProject/Controllers/GroupController.cs
+++ b/HumanResourceProject/Controllers/GroupController.cs
@@ -19,8 +19,8 @@ namespace PostOfficeProject.Controllers
 
         [HttpPost]
         [Route("getAll")]
-        public IActionResult GetAll([FromQuery] QueryParameters queryParameters)
-            => Ok(_groupDomain.GetAllGroups(queryParameters));
+        public IActionResult GetAll([FromQuery] QueryParameters queryParameters, [FromQuery] Guid? studentId)
+            => Ok(_groupDomain.GetAllGroups(queryParameters, studentId));
 
         [HttpGet]
         [Route("{id}")]

--- a/HumanResourceProject/Controllers/ScheduleController.cs
+++ b/HumanResourceProject/Controllers/ScheduleController.cs
@@ -1,3 +1,4 @@
+using System;
 using Domain.Contracts;
 using DTO;
 using Helpers.Pagination;
@@ -18,8 +19,8 @@ namespace PostOfficeProject.Controllers
 
         [HttpPost]
         [Route("getAll")]
-        public IActionResult GetAll([FromQuery] QueryParameters queryParameters)
-            => Ok(_scheduleDomain.GetAllSchedules(queryParameters));
+        public IActionResult GetAll([FromQuery] QueryParameters queryParameters, [FromQuery] Guid? groupId, [FromQuery] Guid? studentId, [FromQuery] Guid? teacherId)
+            => Ok(_scheduleDomain.GetAllSchedules(queryParameters, groupId, studentId, teacherId));
 
         [HttpGet]
         [Route("{id}")]


### PR DESCRIPTION
## Summary
- allow fetching student-specific groups
- enable retrieving schedules filtered by group, student, or teacher

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b396ef831883328b541f69b9c38586