### PR TITLE
Add session management APIs

### DIFF
--- a/DAL/Concrete/SessionRepository.cs
+++ b/DAL/Concrete/SessionRepository.cs
@@ -1,0 +1,67 @@
+using DAL.Contracts;
+using Entities.Models;
+using Helpers;
+using System;
+using System.Linq;
+
+namespace DAL.Concrete
+{
+    internal class SessionRepository : BaseRepository<TblSession, Guid>, ISessionRepository
+    {
+        private readonly SchoolAdministrationContext _dbContext;
+
+        public SessionRepository(SchoolAdministrationContext dbContext) : base(dbContext)
+        {
+            _dbContext = dbContext;
+        }
+
+        public TblSession CreateSession(Guid scheduleId)
+        {
+            var schedule = _dbContext.TblSchedules.FirstOrDefault(s => s.Id == scheduleId && s.Status != EntityStatus.Deleted);
+            if (schedule == null) throw new Exception("Schedule not found");
+
+            var today = DateTime.UtcNow.Date;
+            var sessionDate = today.Add(schedule.StartTime.TimeOfDay);
+
+            var session = new TblSession
+            {
+                Id = Guid.NewGuid(),
+                ScheduleId = scheduleId,
+                Date = sessionDate,
+                IsOpen = true,
+                Otp = GenerateOtp(),
+                OtpcreatedAt = DateTime.UtcNow,
+                Status = EntityStatus.Active
+            };
+
+            return Add(session);
+        }
+
+        public TblSession RegenerateOtp(Guid sessionId)
+        {
+            var session = context.FirstOrDefault(s => s.Id == sessionId && s.Status != EntityStatus.Deleted);
+            if (session == null) throw new Exception("Session not found");
+
+            session.Otp = GenerateOtp();
+            session.OtpcreatedAt = DateTime.UtcNow;
+            Update(session);
+            return session;
+        }
+
+        public TblSession CloseSession(Guid sessionId)
+        {
+            var session = context.FirstOrDefault(s => s.Id == sessionId && s.Status != EntityStatus.Deleted);
+            if (session == null) throw new Exception("Session not found");
+
+            session.IsOpen = false;
+            Update(session);
+            return session;
+        }
+
+        private string GenerateOtp()
+        {
+            var random = new Random();
+            return random.Next(100000, 999999).ToString();
+        }
+    }
+}

--- a/DAL/Contracts/ISessionRepository.cs
+++ b/DAL/Contracts/ISessionRepository.cs
@@ -1,0 +1,12 @@
+using Entities.Models;
+using System;
+
+namespace DAL.Contracts
+{
+    public interface ISessionRepository : IRepository<TblSession, Guid>
+    {
+        TblSession CreateSession(Guid scheduleId);
+        TblSession RegenerateOtp(Guid sessionId);
+        TblSession CloseSession(Guid sessionId);
+    }
+}

--- a/DAL/DI/RepositoryRegistry.cs
+++ b/DAL/DI/RepositoryRegistry.cs
@@ -27,6 +27,7 @@ namespace DAL.DI
             For<IGroupStudentRepository>().Use<GroupStudentRepository>();
             For<ITeacherRepository>().Use<TeacherRepository>();
             For<IScheduleRepository>().Use<ScheduleRepository>();
+            For<ISessionRepository>().Use<SessionRepository>();
             //    For<IHistoryRepository>().Use<HistoryRepository>();
             //    For<IPostOfficeRepository>().Use<PostOfficeRepository>();
             //    For<IPackageRepository>().Use<PackageRepository>();

--- a/DTO/SessionDTO.cs
+++ b/DTO/SessionDTO.cs
@@ -1,0 +1,18 @@
+using System;
+using Helpers;
+
+namespace DTO
+{
+    public class SessionDTO
+    {
+        public Guid Id { get; set; }
+        public Guid ScheduleId { get; set; }
+        public DateTime Date { get; set; }
+        public bool? IsOpen { get; set; }
+        public string? Otp { get; set; }
+        public DateTime? OtpcreatedAt { get; set; }
+        public EntityStatus Status { get; set; }
+
+        public ScheduleDTO Schedule { get; set; }
+    }
+}

--- a/Domain/Concrete/SessionDomain.cs
+++ b/Domain/Concrete/SessionDomain.cs
@@ -1,0 +1,40 @@
+using AutoMapper;
+using DAL.Contracts;
+using DAL.UoW;
+using Domain.Contracts;
+using DTO;
+using Microsoft.AspNetCore.Http;
+using System;
+
+namespace Domain.Concrete
+{
+    internal class SessionDomain : DomainBase, ISessionDomain
+    {
+        public SessionDomain(IUnitOfWork unitOfWork, IMapper mapper, IHttpContextAccessor httpContextAccessor) : base(unitOfWork, mapper, httpContextAccessor)
+        {
+        }
+
+        private ISessionRepository SessionRepository => _unitOfWork.GetRepository<ISessionRepository>();
+
+        public SessionDTO CreateSession(Guid scheduleId)
+        {
+            var entity = SessionRepository.CreateSession(scheduleId);
+            _unitOfWork.Save();
+            return _mapper.Map<SessionDTO>(entity);
+        }
+
+        public SessionDTO RegenerateOtp(Guid sessionId)
+        {
+            var entity = SessionRepository.RegenerateOtp(sessionId);
+            _unitOfWork.Save();
+            return _mapper.Map<SessionDTO>(entity);
+        }
+
+        public SessionDTO CloseSession(Guid sessionId)
+        {
+            var entity = SessionRepository.CloseSession(sessionId);
+            _unitOfWork.Save();
+            return _mapper.Map<SessionDTO>(entity);
+        }
+    }
+}

--- a/Domain/Contracts/ISessionDomain.cs
+++ b/Domain/Contracts/ISessionDomain.cs
@@ -1,0 +1,12 @@
+using System;
+using DTO;
+
+namespace Domain.Contracts
+{
+    public interface ISessionDomain
+    {
+        SessionDTO CreateSession(Guid scheduleId);
+        SessionDTO RegenerateOtp(Guid sessionId);
+        SessionDTO CloseSession(Guid sessionId);
+    }
+}

--- a/Domain/DI/DomainRegistry.cs
+++ b/Domain/DI/DomainRegistry.cs
@@ -27,6 +27,7 @@ namespace Domain.DI
             For<IGroupDomain>().Use<GroupDomain>();
             For<ITeacherDomain>().Use<TeacherDomain>();
             For<IScheduleDomain>().Use<ScheduleDomain>();
+            For<ISessionDomain>().Use<SessionDomain>();
 
             AddRepositoryRegistries();
             AddHttpContextRegistries();

--- a/Domain/Mappings/GeneralProfile.cs
+++ b/Domain/Mappings/GeneralProfile.cs
@@ -104,6 +104,12 @@ namespace Domain.Mappings
                 .ForMember(dest => dest.AcademicYear, opt => opt.Ignore());
             CreateMap<TblSchedule, SchedulePostDTO>().ReverseMap();
             #endregion
+            #region sessions
+            CreateMap<TblSession, SessionDTO>()
+                .ForMember(dest => dest.Schedule, opt => opt.MapFrom(src => src.Schedule))
+                .ReverseMap()
+                .ForMember(dest => dest.Schedule, opt => opt.Ignore());
+            #endregion
         }
 
 

--- a/HumanResourceProject/Controllers/SessionController.cs
+++ b/HumanResourceProject/Controllers/SessionController.cs
@@ -1,0 +1,33 @@
+using Domain.Contracts;
+using Microsoft.AspNetCore.Mvc;
+using System;
+
+namespace PostOfficeProject.Controllers
+{
+    [ApiController]
+    [Route("[controller]")]
+    public class SessionController : ControllerBase
+    {
+        private readonly ISessionDomain _sessionDomain;
+
+        public SessionController(ISessionDomain sessionDomain)
+        {
+            _sessionDomain = sessionDomain;
+        }
+
+        [HttpPost]
+        [Route("{scheduleId}")]
+        public IActionResult Create([FromRoute] Guid scheduleId)
+            => Ok(_sessionDomain.CreateSession(scheduleId));
+
+        [HttpPost]
+        [Route("{sessionId}/regenerate-otp")]
+        public IActionResult RegenerateOtp([FromRoute] Guid sessionId)
+            => Ok(_sessionDomain.RegenerateOtp(sessionId));
+
+        [HttpPost]
+        [Route("{sessionId}/close")]
+        public IActionResult Close([FromRoute] Guid sessionId)
+            => Ok(_sessionDomain.CloseSession(sessionId));
+    }
+}


### PR DESCRIPTION
## Summary
- add session DTO, repository, and domain for handling sessions
- support creating sessions with OTP generation and manual closure
- expose endpoints to regenerate OTPs and close sessions

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b39ad74cb483329ca1894ca7502182