### PR TITLE
Return group students with user info

### DIFF
--- a/DAL/Concrete/GroupRepository.cs
+++ b/DAL/Concrete/GroupRepository.cs
@@ -37,6 +37,8 @@ namespace DAL.Concrete
                 .Include(g => g.Course)
                 .Include(g => g.AcademicYear)
                 .Include(g => g.TblGroupStudents)
+                    .ThenInclude(gs => gs.Student)
+                        .ThenInclude(s => s.User)
                 .FirstOrDefault(g => g.Id == id && g.Status != EntityStatus.Deleted);
         }
     }

--- a/DTO/GroupDTO.cs
+++ b/DTO/GroupDTO.cs
@@ -13,6 +13,7 @@ namespace DTO
         public CourseDTO Course { get; set; }
         public AcademicYearDTO AcademicYear { get; set; }
         public List<Guid> StudentIds { get; set; }
+        public List<StudentCardDTO> Students { get; set; }
         public int StudentsLength { get; set; }
         public EntityStatus Status { get; set; }
     }

--- a/Domain/Mappings/GeneralProfile.cs
+++ b/Domain/Mappings/GeneralProfile.cs
@@ -82,6 +82,9 @@ namespace Domain.Mappings
                 .ForMember(dest => dest.Course, opt => opt.MapFrom(src => src.Course))
                 .ForMember(dest => dest.AcademicYear, opt => opt.MapFrom(src => src.AcademicYear))
                 .ForMember(dest => dest.StudentIds, opt => opt.MapFrom(src => src.TblGroupStudents.Select(gs => gs.StudentId)))
+                .ForMember(dest => dest.Students, opt => opt.MapFrom(src => src.TblGroupStudents
+                    .Where(gs => gs.Student != null)
+                    .Select(gs => gs.Student)))
                 .ForMember(dest => dest.StudentsLength, opt => opt.MapFrom(src => src.TblGroupStudents.Count))
                 .ReverseMap()
                 .ForMember(dest => dest.Course, opt => opt.Ignore())


### PR DESCRIPTION
## Summary
- include student list with user details in group DTO
- load student and user data when fetching a group by id
- map group students to DTO

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: The repository 'http://archive.ubuntu.com/ubuntu noble InRelease' is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b4328ece888332ab7510c816c4b2e9