### PR TITLE
Refine group student responses

### DIFF
--- a/DAL/Concrete/StudentCardRepository.cs
+++ b/DAL/Concrete/StudentCardRepository.cs
@@ -4,6 +4,7 @@ using Helpers;
 using Helpers.Pagination;
 using Microsoft.EntityFrameworkCore;
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using static Helpers.Pagination.QueryParameters;
 
@@ -44,6 +45,16 @@ namespace DAL.Concrete
                 data = data.Where(x => x.DepartmentId == departmentId.Value);
             var filterData = PaginationConfiguration(data, queryParameters.SortField, queryParameters.SortOrder, queryParameters.SearchValue);
             return PagedList<TblStudentCard>.ToPagedList(filterData, queryParameters == null ? 1 : queryParameters.CurrentPage, queryParameters == null ? 10 : queryParameters.PageSize);
+        }
+
+        public IEnumerable<TblStudentCard> GetByIds(IEnumerable<Guid> ids)
+        {
+            return context
+                .Include(x => x.User)
+                .Include(x => x.Department)
+                .Include(x => x.AcademicYear)
+                .Where(x => ids.Contains(x.Id) && x.Status != EntityStatus.Deleted)
+                .ToList();
         }
 
         public override TblStudentCard GetById(Guid id)

--- a/DAL/Contracts/IStudentCardRepository.cs
+++ b/DAL/Contracts/IStudentCardRepository.cs
@@ -2,6 +2,7 @@ using Entities.Models;
 using Helpers.Pagination;
 using static Helpers.Pagination.QueryParameters;
 using System;
+using System.Collections.Generic;
 
 namespace DAL.Contracts
 {
@@ -9,5 +10,6 @@ namespace DAL.Contracts
     {
         PagedList<TblStudentCard> GetStudentCards(QueryParameters queryParameters, Guid? userId, Guid? academicYearId, Guid? departmentId);
         void DisableCardsByUser(Guid userId);
+        IEnumerable<TblStudentCard> GetByIds(IEnumerable<Guid> ids);
     }
 }

--- a/DTO/GroupDTO.cs
+++ b/DTO/GroupDTO.cs
@@ -13,7 +13,6 @@ namespace DTO
         public CourseDTO Course { get; set; }
         public AcademicYearDTO AcademicYear { get; set; }
         public List<Guid> StudentIds { get; set; }
-        public List<StudentCardDTO> Students { get; set; }
         public int StudentsLength { get; set; }
         public EntityStatus Status { get; set; }
     }

--- a/Domain/Concrete/GroupDomain.cs
+++ b/Domain/Concrete/GroupDomain.cs
@@ -21,6 +21,7 @@ namespace Domain.Concrete
 
         private IGroupRepository GroupRepository => _unitOfWork.GetRepository<IGroupRepository>();
         private IGroupStudentRepository GroupStudentRepository => _unitOfWork.GetRepository<IGroupStudentRepository>();
+        private IStudentCardRepository StudentCardRepository => _unitOfWork.GetRepository<IStudentCardRepository>();
 
         public void AddNew(GroupPostDTO group)
         {
@@ -141,9 +142,14 @@ namespace Domain.Concrete
             _unitOfWork.Save();
         }
 
-        public IEnumerable<Guid> GetStudents(Guid groupId)
+        public IEnumerable<StudentCardDTO> GetStudents(Guid groupId)
         {
-            return GroupStudentRepository.GetStudentIdsByGroupId(groupId);
+            var studentIds = GroupStudentRepository.GetStudentIdsByGroupId(groupId).ToList();
+            if (!studentIds.Any())
+                return new List<StudentCardDTO>();
+
+            var students = StudentCardRepository.GetByIds(studentIds);
+            return _mapper.Map<IEnumerable<StudentCardDTO>>(students);
         }
     }
 }

--- a/Domain/Contracts/IGroupDomain.cs
+++ b/Domain/Contracts/IGroupDomain.cs
@@ -14,6 +14,6 @@ namespace Domain.Contracts
         void Delete(Guid id);
         void AddStudents(Guid groupId, GroupStudentPostDTO dto);
         void RemoveStudents(Guid groupId, GroupStudentPostDTO dto);
-        IEnumerable<Guid> GetStudents(Guid groupId);
+        IEnumerable<StudentCardDTO> GetStudents(Guid groupId);
     }
 }

--- a/Domain/Mappings/GeneralProfile.cs
+++ b/Domain/Mappings/GeneralProfile.cs
@@ -82,9 +82,6 @@ namespace Domain.Mappings
                 .ForMember(dest => dest.Course, opt => opt.MapFrom(src => src.Course))
                 .ForMember(dest => dest.AcademicYear, opt => opt.MapFrom(src => src.AcademicYear))
                 .ForMember(dest => dest.StudentIds, opt => opt.MapFrom(src => src.TblGroupStudents.Select(gs => gs.StudentId)))
-                .ForMember(dest => dest.Students, opt => opt.MapFrom(src => src.TblGroupStudents
-                    .Where(gs => gs.Student != null)
-                    .Select(gs => gs.Student)))
                 .ForMember(dest => dest.StudentsLength, opt => opt.MapFrom(src => src.TblGroupStudents.Count))
                 .ReverseMap()
                 .ForMember(dest => dest.Course, opt => opt.Ignore())


### PR DESCRIPTION
## Summary
- Avoid returning full student objects when fetching a group by id
- Return detailed student records from group students endpoint, including user info
- Update mappings and contracts for new student return type

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b4343e089c8332ae17c33c5ced3468