### PR TITLE
Link groups to programs

### DIFF
--- a/DAL/Concrete/ScheduleRepository.cs
+++ b/DAL/Concrete/ScheduleRepository.cs
@@ -19,7 +19,7 @@ namespace DAL.Concrete
         {
             var data = context
                 .Where(s => s.Status != EntityStatus.Deleted)
-                .Include(s => s.Course)
+                .Include(s => s.Program)
                 .Include(s => s.Group).ThenInclude(g => g.Program).ThenInclude(p => p.Department)
                 .Include(s => s.Group).ThenInclude(g => g.TblGroupStudents)
                 .Include(s => s.Teacher).ThenInclude(t => t.User)
@@ -57,7 +57,7 @@ namespace DAL.Concrete
         public override TblSchedule GetById(Guid id)
         {
             return context
-                .Include(s => s.Course)
+                .Include(s => s.Program)
                 .Include(s => s.Group).ThenInclude(g => g.Program).ThenInclude(p => p.Department)
                 .Include(s => s.Group).ThenInclude(g => g.TblGroupStudents)
                 .Include(s => s.Teacher).ThenInclude(t => t.User)

--- a/DTO/ScheduleDTO.cs
+++ b/DTO/ScheduleDTO.cs
@@ -7,7 +7,7 @@ namespace DTO
     {
         public Guid Id { get; set; }
         public Guid GroupId { get; set; }
-        public Guid CourseId { get; set; }
+        public Guid ProgramId { get; set; }
         public Guid TeacherId { get; set; }
         public Guid RoomId { get; set; }
         public Guid AcademicYearId { get; set; }
@@ -18,7 +18,7 @@ namespace DTO
         public EntityStatus Status { get; set; }
 
         public GroupDTO Group { get; set; }
-        public CourseDTO Course { get; set; }
+        public ProgramDTO Program { get; set; }
         public TeacherDTO Teacher { get; set; }
         public RoomDTO Room { get; set; }
         public AcademicYearDTO AcademicYear { get; set; }
@@ -27,7 +27,7 @@ namespace DTO
     public class SchedulePostDTO
     {
         public Guid? GroupId { get; set; }
-        public Guid? CourseId { get; set; }
+        public Guid? ProgramId { get; set; }
         public Guid? TeacherId { get; set; }
         public Guid? RoomId { get; set; }
         public Guid? AcademicYearId { get; set; }

--- a/Domain/Concrete/ScheduleDomain.cs
+++ b/Domain/Concrete/ScheduleDomain.cs
@@ -67,8 +67,8 @@ namespace Domain.Concrete
             }
             if (schedule.GroupId.HasValue)
                 entity.GroupId = schedule.GroupId.Value;
-            if (schedule.CourseId.HasValue)
-                entity.CourseId = schedule.CourseId.Value;
+            if (schedule.ProgramId.HasValue)
+                entity.ProgramId = schedule.ProgramId.Value;
             if (schedule.TeacherId.HasValue)
                 entity.TeacherId = schedule.TeacherId.Value;
             if (schedule.RoomId.HasValue)

--- a/Domain/Mappings/GeneralProfile.cs
+++ b/Domain/Mappings/GeneralProfile.cs
@@ -105,13 +105,13 @@ namespace Domain.Mappings
             #region schedules
             CreateMap<TblSchedule, ScheduleDTO>()
                 .ForMember(dest => dest.Group, opt => opt.MapFrom(src => src.Group))
-                .ForMember(dest => dest.Course, opt => opt.MapFrom(src => src.Course))
+                .ForMember(dest => dest.Program, opt => opt.MapFrom(src => src.Program))
                 .ForMember(dest => dest.Teacher, opt => opt.MapFrom(src => src.Teacher))
                 .ForMember(dest => dest.Room, opt => opt.MapFrom(src => src.Room))
                 .ForMember(dest => dest.AcademicYear, opt => opt.MapFrom(src => src.AcademicYear))
                 .ReverseMap()
                 .ForMember(dest => dest.Group, opt => opt.Ignore())
-                .ForMember(dest => dest.Course, opt => opt.Ignore())
+                .ForMember(dest => dest.Program, opt => opt.Ignore())
                 .ForMember(dest => dest.Teacher, opt => opt.Ignore())
                 .ForMember(dest => dest.Room, opt => opt.Ignore())
                 .ForMember(dest => dest.AcademicYear, opt => opt.Ignore());

--- a/Entities/Models/SchoolAdministrationContext.cs
+++ b/Entities/Models/SchoolAdministrationContext.cs
@@ -236,11 +236,11 @@ namespace Entities.Models
 
                 entity.Property(e => e.Status).HasDefaultValueSql("((1))");
 
-                entity.HasOne(d => d.Course)
+                entity.HasOne(d => d.Program)
                     .WithMany(p => p.TblSchedules)
-                    .HasForeignKey(d => d.CourseId)
+                    .HasForeignKey(d => d.ProgramId)
                     .OnDelete(DeleteBehavior.ClientSetNull)
-                    .HasConstraintName("FK__tblSchedu__Cours__09A971A2");
+                    .HasConstraintName("FK__tblSchedu__Progr__09A971A2");
 
                 entity.HasOne(d => d.Group)
                     .WithMany(p => p.TblSchedules)

--- a/Entities/Models/TblCourse.cs
+++ b/Entities/Models/TblCourse.cs
@@ -9,7 +9,6 @@ namespace Entities.Models
         public TblCourse()
         {
             TblAbsenceWarnings = new HashSet<TblAbsenceWarning>();
-            TblSchedules = new HashSet<TblSchedule>();
         }
 
         public Guid Id { get; set; }
@@ -21,6 +20,5 @@ namespace Entities.Models
 
         public virtual TblProgram Program { get; set; } = null!;
         public virtual ICollection<TblAbsenceWarning> TblAbsenceWarnings { get; set; }
-        public virtual ICollection<TblSchedule> TblSchedules { get; set; }
     }
 }

--- a/Entities/Models/TblProgram.cs
+++ b/Entities/Models/TblProgram.cs
@@ -11,6 +11,7 @@ namespace Entities.Models
             TblCourses = new HashSet<TblCourse>();
             TblGroups = new HashSet<TblGroup>();
             TblStudentCards = new HashSet<TblStudentCard>();
+            TblSchedules = new HashSet<TblSchedule>();
         }
 
         public Guid Id { get; set; }
@@ -22,5 +23,6 @@ namespace Entities.Models
         public virtual ICollection<TblCourse> TblCourses { get; set; }
         public virtual ICollection<TblGroup> TblGroups { get; set; }
         public virtual ICollection<TblStudentCard> TblStudentCards { get; set; }
+        public virtual ICollection<TblSchedule> TblSchedules { get; set; }
     }
 }

--- a/Entities/Models/TblSchedule.cs
+++ b/Entities/Models/TblSchedule.cs
@@ -13,7 +13,7 @@ namespace Entities.Models
 
         public Guid Id { get; set; }
         public Guid GroupId { get; set; }
-        public Guid CourseId { get; set; }
+        public Guid ProgramId { get; set; }
         public Guid TeacherId { get; set; }
         public Guid RoomId { get; set; }
         public Guid AcademicYearId { get; set; }
@@ -23,7 +23,7 @@ namespace Entities.Models
         public RoomType ScheduleType { get; set; }
         public EntityStatus Status { get; set; }
 
-        public virtual TblCourse Course { get; set; } = null!;
+        public virtual TblProgram Program { get; set; } = null!;
         public virtual TblGroup Group { get; set; } = null!;
         public virtual TblAcademicYear AcademicYear { get; set; } = null!;
         public virtual TblRoom Room { get; set; } = null!;


### PR DESCRIPTION
## Summary
- replace course linkage with program in schedules
- expose program identifiers in schedule DTOs and mappings
- update domain logic and EF context for program-based schedules

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b45e522c308332a8a95d3fd8fb0a56