### PR TITLE
Add API to retrieve teacher by user ID

### DIFF
--- a/DAL/Concrete/TeacherRepository.cs
+++ b/DAL/Concrete/TeacherRepository.cs
@@ -26,5 +26,10 @@ namespace DAL.Concrete
         {
             return context.Include(t => t.User).FirstOrDefault(t => t.Id == id && t.Status != EntityStatus.Deleted);
         }
+
+        public TblTeacher GetByUserId(Guid userId)
+        {
+            return context.Include(t => t.User).FirstOrDefault(t => t.UserId == userId && t.Status != EntityStatus.Deleted);
+        }
     }
 }

--- a/DAL/Contracts/ITeacherRepository.cs
+++ b/DAL/Contracts/ITeacherRepository.cs
@@ -7,5 +7,6 @@ namespace DAL.Contracts
     public interface ITeacherRepository : IRepository<TblTeacher, Guid>
     {
         PagedList<TblTeacher> GetTeachers(QueryParameters queryParameters);
+        TblTeacher GetByUserId(Guid userId);
     }
 }

--- a/Domain/Concrete/TeacherDomain.cs
+++ b/Domain/Concrete/TeacherDomain.cs
@@ -78,6 +78,16 @@ namespace Domain.Concrete
             return _mapper.Map<TeacherDTO>(entity);
         }
 
+        public TeacherDTO GetTeacherByUserId(Guid userId)
+        {
+            var entity = TeacherRepository.GetByUserId(userId);
+            if (entity == null)
+            {
+                throw new Exception("Teacher not found");
+            }
+            return _mapper.Map<TeacherDTO>(entity);
+        }
+
         public TeacherDTO Update(Guid id, TeacherPostDTO teacherPostDTO)
         {
             var entity = TeacherRepository.GetById(id);

--- a/Domain/Contracts/ITeacherDomain.cs
+++ b/Domain/Contracts/ITeacherDomain.cs
@@ -7,6 +7,7 @@ namespace Domain.Contracts
     {
         Pagination<TeacherDTO> GetAllTeachers(QueryParameters queryParameters);
         TeacherDTO GetTeacherById(Guid id);
+        TeacherDTO GetTeacherByUserId(Guid userId);
         TeacherDTO AddNew(TeacherPostDTO teacherPostDTO);
         TeacherDTO Update(Guid id, TeacherPostDTO teacherPostDTO);
         void Delete(Guid id);

--- a/HumanResourceProject/Controllers/TeacherController.cs
+++ b/HumanResourceProject/Controllers/TeacherController.cs
@@ -26,6 +26,11 @@ namespace PostOfficeProject.Controllers
         public IActionResult GetById([FromRoute] Guid id)
             => Ok(_teacherDomain.GetTeacherById(id));
 
+        [HttpGet]
+        [Route("user/{userId}")]
+        public IActionResult GetByUserId([FromRoute] Guid userId)
+            => Ok(_teacherDomain.GetTeacherByUserId(userId));
+
         [HttpPost]
         [Route("add")]
         public IActionResult AddNew([FromBody] TeacherPostDTO dto)


### PR DESCRIPTION
## Summary
- add repository and domain support for fetching a teacher by user ID
- expose new `GET /teacher/user/{userId}` endpoint

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: The repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b49e8afd7c8332bed3873c64d3ae9f