### PR TITLE
feat: add session retrieval endpoint

### DIFF
--- a/DAL/Concrete/SessionRepository.cs
+++ b/DAL/Concrete/SessionRepository.cs
@@ -100,6 +100,17 @@ namespace DAL.Concrete
                 queryParameters?.PageSize ?? 10);
         }
 
+        public override TblSession GetById(Guid id)
+        {
+            return context
+                .Include(s => s.Schedule).ThenInclude(sc => sc.Course).ThenInclude(c => c.Program)
+                .Include(s => s.Schedule).ThenInclude(sc => sc.Group)
+                .Include(s => s.Schedule).ThenInclude(sc => sc.Teacher).ThenInclude(t => t.User)
+                .Include(s => s.Schedule).ThenInclude(sc => sc.Room)
+                .Include(s => s.Schedule).ThenInclude(sc => sc.AcademicYear)
+                .FirstOrDefault(s => s.Id == id && s.Status != EntityStatus.Deleted);
+        }
+
         private string GenerateOtp()
         {
             var random = new Random();

--- a/Domain/Concrete/SessionDomain.cs
+++ b/Domain/Concrete/SessionDomain.cs
@@ -49,5 +49,15 @@ namespace Domain.Concrete
 
             return paginatedData;
         }
+
+        public SessionDTO GetSessionById(Guid sessionId)
+        {
+            var session = SessionRepository.GetById(sessionId);
+            if (session == null)
+            {
+                throw new Exception("Session not found");
+            }
+            return _mapper.Map<SessionDTO>(session);
+        }
     }
 }

--- a/Domain/Contracts/ISessionDomain.cs
+++ b/Domain/Contracts/ISessionDomain.cs
@@ -10,5 +10,6 @@ namespace Domain.Contracts
         SessionDTO RegenerateOtp(Guid sessionId);
         SessionDTO CloseSession(Guid sessionId);
         Pagination<SessionDTO> GetAllSessions(QueryParameters queryParameters, Guid? teacherId);
+        SessionDTO GetSessionById(Guid sessionId);
     }
 }

--- a/HumanResourceProject/Controllers/SessionController.cs
+++ b/HumanResourceProject/Controllers/SessionController.cs
@@ -35,5 +35,10 @@ namespace PostOfficeProject.Controllers
         [Route("{sessionId}/close")]
         public IActionResult Close([FromRoute] Guid sessionId)
             => Ok(_sessionDomain.CloseSession(sessionId));
+
+        [HttpGet]
+        [Route("{sessionId}")]
+        public IActionResult GetById([FromRoute] Guid sessionId)
+            => Ok(_sessionDomain.GetSessionById(sessionId));
     }
 }


### PR DESCRIPTION
## Summary
- add GetSessionById to domain and controller
- load related schedule details when fetching a session
- expose API endpoint to fetch session by ID

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: 403  Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b4a24a68108332a9ee501185b440e9