### PR TITLE
Compute course session capacity for absence warnings

### DIFF
--- a/DAL/Concrete/AbsenceWarningRepository.cs
+++ b/DAL/Concrete/AbsenceWarningRepository.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Linq;
+using DAL.Contracts;
+using Entities.Models;
+using Helpers;
+
+namespace DAL.Concrete
+{
+    internal class AbsenceWarningRepository : BaseRepository<TblAbsenceWarning, Guid>, IAbsenceWarningRepository
+    {
+        public AbsenceWarningRepository(SchoolAdministrationContext dbContext) : base(dbContext)
+        {
+        }
+
+        public TblAbsenceWarning AddOrUpdate(Guid studentId, Guid courseId, double percentage)
+        {
+            var entity = context.FirstOrDefault(x => x.StudentId == studentId && x.CourseId == courseId);
+            if (entity == null)
+            {
+                entity = new TblAbsenceWarning
+                {
+                    Id = Guid.NewGuid(),
+                    StudentId = studentId,
+                    CourseId = courseId,
+                    Percentage = percentage,
+                    SentAt = DateTime.UtcNow,
+                    Status = EntityStatus.Active
+                };
+                Add(entity);
+            }
+            else
+            {
+                entity.Percentage = percentage;
+                entity.SentAt = DateTime.UtcNow;
+                Update(entity);
+            }
+            return entity;
+        }
+    }
+}

--- a/DAL/Concrete/AttendanceRepository.cs
+++ b/DAL/Concrete/AttendanceRepository.cs
@@ -39,5 +39,15 @@ namespace DAL.Concrete
         {
             return _dbContext.TblAttendances.Where(a => a.StudentId == studentCardId && a.Status != EntityStatus.Deleted).AsNoTracking().ToList();
         }
+
+        public bool HasAttendance(Guid sessionId, Guid studentId)
+        {
+            return context.Any(a => a.SessionId == sessionId && a.StudentId == studentId && a.Status != EntityStatus.Deleted);
+        }
+
+        public int CountAttendances(Guid studentId, IEnumerable<Guid> sessionIds)
+        {
+            return context.Count(a => a.StudentId == studentId && sessionIds.Contains(a.SessionId) && a.Status != EntityStatus.Deleted);
+        }
     }
 }

--- a/DAL/Concrete/SessionRepository.cs
+++ b/DAL/Concrete/SessionRepository.cs
@@ -5,6 +5,7 @@ using Helpers.Pagination;
 using Microsoft.EntityFrameworkCore;
 using System;
 using System.Linq;
+using System.Collections.Generic;
 using static Helpers.Pagination.QueryParameters;
 
 namespace DAL.Concrete
@@ -109,6 +110,18 @@ namespace DAL.Concrete
                 .Include(s => s.Schedule).ThenInclude(sc => sc.Room)
                 .Include(s => s.Schedule).ThenInclude(sc => sc.AcademicYear)
                 .FirstOrDefault(s => s.Id == id && s.Status != EntityStatus.Deleted);
+        }
+
+        public IEnumerable<Guid> GetSessionIdsByCourseAndGroup(Guid courseId, Guid groupId, Guid academicYearId)
+        {
+            return context
+                .Include(s => s.Schedule)
+                .Where(s => s.Schedule.CourseId == courseId
+                         && s.Schedule.GroupId == groupId
+                         && s.Schedule.AcademicYearId == academicYearId
+                         && s.Status != EntityStatus.Deleted)
+                .Select(s => s.Id)
+                .ToList();
         }
 
         private string GenerateOtp()

--- a/DAL/Contracts/IAbsenceWarningRepository.cs
+++ b/DAL/Contracts/IAbsenceWarningRepository.cs
@@ -1,0 +1,10 @@
+using Entities.Models;
+using System;
+
+namespace DAL.Contracts
+{
+    public interface IAbsenceWarningRepository : IRepository<TblAbsenceWarning, Guid>
+    {
+        TblAbsenceWarning AddOrUpdate(Guid studentId, Guid courseId, double percentage);
+    }
+}

--- a/DAL/Contracts/IAttendanceRepository.cs
+++ b/DAL/Contracts/IAttendanceRepository.cs
@@ -8,5 +8,7 @@ namespace DAL.Contracts
     {
         TblAttendance CheckIn(string studentCardCode, Guid sessionId);
         IEnumerable<TblAttendance> GetByStudent(Guid studentCardId);
+        bool HasAttendance(Guid sessionId, Guid studentId);
+        int CountAttendances(Guid studentId, IEnumerable<Guid> sessionIds);
     }
 }

--- a/DAL/Contracts/ISessionRepository.cs
+++ b/DAL/Contracts/ISessionRepository.cs
@@ -1,6 +1,7 @@
 using Entities.Models;
 using Helpers.Pagination;
 using System;
+using System.Collections.Generic;
 using static Helpers.Pagination.QueryParameters;
 
 namespace DAL.Contracts
@@ -11,5 +12,6 @@ namespace DAL.Contracts
         TblSession RegenerateOtp(Guid sessionId);
         TblSession CloseSession(Guid sessionId);
         PagedList<TblSession> GetSessions(QueryParameters queryParameters, Guid? teacherId = null);
+        IEnumerable<Guid> GetSessionIdsByCourseAndGroup(Guid courseId, Guid groupId, Guid academicYearId);
     }
 }

--- a/DAL/DI/RepositoryRegistry.cs
+++ b/DAL/DI/RepositoryRegistry.cs
@@ -29,6 +29,7 @@ namespace DAL.DI
             For<ITeacherRepository>().Use<TeacherRepository>();
             For<IScheduleRepository>().Use<ScheduleRepository>();
             For<ISessionRepository>().Use<SessionRepository>();
+            For<IAbsenceWarningRepository>().Use<AbsenceWarningRepository>();
             //    For<IHistoryRepository>().Use<HistoryRepository>();
             //    For<IPostOfficeRepository>().Use<PostOfficeRepository>();
             //    For<IPackageRepository>().Use<PackageRepository>();

--- a/Domain/Concrete/SessionDomain.cs
+++ b/Domain/Concrete/SessionDomain.cs
@@ -3,20 +3,30 @@ using DAL.Contracts;
 using DAL.UoW;
 using Domain.Contracts;
 using DTO;
+using Helpers.Email;
 using Helpers.Pagination;
 using Microsoft.AspNetCore.Http;
 using System;
 using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
 
 namespace Domain.Concrete
 {
     internal class SessionDomain : DomainBase, ISessionDomain
     {
-        public SessionDomain(IUnitOfWork unitOfWork, IMapper mapper, IHttpContextAccessor httpContextAccessor) : base(unitOfWork, mapper, httpContextAccessor)
+        private readonly EmailService _emailService;
+
+        public SessionDomain(IUnitOfWork unitOfWork, IMapper mapper, IHttpContextAccessor httpContextAccessor, EmailService emailService) : base(unitOfWork, mapper, httpContextAccessor)
         {
+            _emailService = emailService;
         }
 
         private ISessionRepository SessionRepository => _unitOfWork.GetRepository<ISessionRepository>();
+        private IGroupStudentRepository GroupStudentRepository => _unitOfWork.GetRepository<IGroupStudentRepository>();
+        private IAttendanceRepository AttendanceRepository => _unitOfWork.GetRepository<IAttendanceRepository>();
+        private IStudentCardRepository StudentCardRepository => _unitOfWork.GetRepository<IStudentCardRepository>();
+        private IAbsenceWarningRepository AbsenceWarningRepository => _unitOfWork.GetRepository<IAbsenceWarningRepository>();
 
         public SessionDTO CreateSession(Guid scheduleId)
         {
@@ -32,11 +42,57 @@ namespace Domain.Concrete
             return _mapper.Map<SessionDTO>(entity);
         }
 
-        public SessionDTO CloseSession(Guid sessionId)
+        public async Task<SessionDTO> CloseSession(Guid sessionId)
         {
             var entity = SessionRepository.CloseSession(sessionId);
             _unitOfWork.Save();
-            return _mapper.Map<SessionDTO>(entity);
+
+            var session = SessionRepository.GetById(sessionId);
+            if (session == null)
+            {
+                throw new Exception("Session not found");
+            }
+
+            var groupId = session.Schedule.GroupId;
+            var courseId = session.Schedule.CourseId;
+            var academicYearId = session.Schedule.AcademicYearId;
+
+            var studentIds = GroupStudentRepository.GetStudentIdsByGroupId(groupId);
+            var sessionIds = SessionRepository.GetSessionIdsByCourseAndGroup(courseId, groupId, academicYearId).ToList();
+
+            var courseTotalHours = session.Schedule.Course.TotalHours ?? 0;
+            var sessionDuration = (session.Schedule.EndTime - session.Schedule.StartTime).TotalHours;
+            var totalSessions = sessionDuration == 0 ? 0 : (int)Math.Ceiling(courseTotalHours / sessionDuration);
+
+            foreach (var studentId in studentIds)
+            {
+                if (AttendanceRepository.HasAttendance(sessionId, studentId))
+                {
+                    continue;
+                }
+
+                var attendedCount = AttendanceRepository.CountAttendances(studentId, sessionIds);
+                var missedCount = Math.Max(0, totalSessions - attendedCount);
+                double attendancePercentage = totalSessions == 0 ? 0 : (double)attendedCount / totalSessions * 100;
+                double absencePercentage = totalSessions == 0 ? 0 : (double)missedCount / totalSessions * 100;
+
+                if (attendancePercentage < 80)
+                {
+                    AbsenceWarningRepository.AddOrUpdate(studentId, courseId, absencePercentage);
+
+                    var student = StudentCardRepository.GetById(studentId);
+                    if (student?.User?.Email != null)
+                    {
+                        await _emailService.SendEmail(
+                            student.User.Email,
+                            "Attendance Warning",
+                            $"Hello {student.User.FirstName} {student.User.LastName},<br/>You have attended {attendedCount} out of {totalSessions} sessions for {session.Schedule.Course.Name} and missed {missedCount}. Your attendance is {attendancePercentage:F2}%. Please attend classes to avoid further actions.");
+                    }
+                }
+            }
+
+            _unitOfWork.Save();
+            return _mapper.Map<SessionDTO>(session);
         }
 
         public Pagination<SessionDTO> GetAllSessions(QueryParameters queryParameters, Guid? teacherId)

--- a/Domain/Contracts/ISessionDomain.cs
+++ b/Domain/Contracts/ISessionDomain.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading.Tasks;
 using DTO;
 using Helpers.Pagination;
 
@@ -8,7 +9,7 @@ namespace Domain.Contracts
     {
         SessionDTO CreateSession(Guid scheduleId);
         SessionDTO RegenerateOtp(Guid sessionId);
-        SessionDTO CloseSession(Guid sessionId);
+        Task<SessionDTO> CloseSession(Guid sessionId);
         Pagination<SessionDTO> GetAllSessions(QueryParameters queryParameters, Guid? teacherId);
         SessionDTO GetSessionById(Guid sessionId);
     }

--- a/HumanResourceProject/Controllers/SessionController.cs
+++ b/HumanResourceProject/Controllers/SessionController.cs
@@ -2,6 +2,7 @@ using Domain.Contracts;
 using Helpers.Pagination;
 using Microsoft.AspNetCore.Mvc;
 using System;
+using System.Threading.Tasks;
 
 namespace PostOfficeProject.Controllers
 {
@@ -33,8 +34,8 @@ namespace PostOfficeProject.Controllers
 
         [HttpPost]
         [Route("{sessionId}/close")]
-        public IActionResult Close([FromRoute] Guid sessionId)
-            => Ok(_sessionDomain.CloseSession(sessionId));
+        public async Task<IActionResult> Close([FromRoute] Guid sessionId)
+            => Ok(await _sessionDomain.CloseSession(sessionId));
 
         [HttpGet]
         [Route("{sessionId}")]


### PR DESCRIPTION
## Summary
- Determine total session count from course total hours and schedule duration
- Calculate attendance and missed sessions against this total
- Include detailed session counts in warning emails

## Testing
- ⚠️ `dotnet build` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b4ad1d11508332bc40ffbbf7426b3a