### PR TITLE
Add Excel export for group session attendance

### DIFF
--- a/DTO/GroupSessionAttendanceDTO.cs
+++ b/DTO/GroupSessionAttendanceDTO.cs
@@ -1,0 +1,15 @@
+using System;
+
+namespace DTO
+{
+    public class GroupSessionAttendanceDTO
+    {
+        public Guid StudentId { get; set; }
+        public string StudentCardCode { get; set; } = null!;
+        public string FirstName { get; set; } = null!;
+        public string LastName { get; set; } = null!;
+        public bool HasAttended { get; set; }
+        public DateTimeOffset? CheckInTime { get; set; }
+    }
+}
+

--- a/Domain/Contracts/IAttendanceDomain.cs
+++ b/Domain/Contracts/IAttendanceDomain.cs
@@ -11,5 +11,6 @@ namespace Domain.Contracts
         IEnumerable<AttendanceDTO> GetBySessionId(Guid sessionId);
         AttendanceDTO AddAttendance(AttendanceAddDTO dto);
         void RemoveAttendance(Guid attendanceId);
+        IEnumerable<GroupSessionAttendanceDTO> GetGroupSessionAttendance(Guid groupId, Guid sessionId);
     }
 }

--- a/HumanResourceProject/Controllers/AttendanceController.cs
+++ b/HumanResourceProject/Controllers/AttendanceController.cs
@@ -1,6 +1,8 @@
 using Domain.Contracts;
 using DTO;
 using Microsoft.AspNetCore.Mvc;
+using ClosedXML.Excel;
+using System.IO;
 using System;
 
 namespace HumanResourceProject.Controllers
@@ -49,6 +51,36 @@ namespace HumanResourceProject.Controllers
         {
             _attendanceDomain.RemoveAttendance(attendanceId);
             return NoContent();
+        }
+
+        [HttpGet("export")]
+        public IActionResult ExportGroupSession([FromQuery] Guid groupId, [FromQuery] Guid sessionId)
+        {
+            var data = _attendanceDomain.GetGroupSessionAttendance(groupId, sessionId);
+            using var workbook = new XLWorkbook();
+            var worksheet = workbook.Worksheets.Add("Attendance");
+            worksheet.Cell(1, 1).Value = "Student Card";
+            worksheet.Cell(1, 2).Value = "First Name";
+            worksheet.Cell(1, 3).Value = "Last Name";
+            worksheet.Cell(1, 4).Value = "Has Attended";
+            worksheet.Cell(1, 5).Value = "Check In Time";
+
+            var row = 2;
+            foreach (var item in data)
+            {
+                worksheet.Cell(row, 1).Value = item.StudentCardCode;
+                worksheet.Cell(row, 2).Value = item.FirstName;
+                worksheet.Cell(row, 3).Value = item.LastName;
+                worksheet.Cell(row, 4).Value = item.HasAttended ? "Yes" : "No";
+                worksheet.Cell(row, 5).Value = item.CheckInTime?.ToString("u");
+                row++;
+            }
+
+            using var stream = new MemoryStream();
+            workbook.SaveAs(stream);
+            stream.Seek(0, SeekOrigin.Begin);
+            var fileName = $"attendance_{groupId}_{sessionId}.xlsx";
+            return File(stream.ToArray(), "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", fileName);
         }
     }
 }

--- a/HumanResourceProject/PostOfficeProject.csproj
+++ b/HumanResourceProject/PostOfficeProject.csproj
@@ -19,6 +19,7 @@
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.2.3" />
     <PackageReference Include="ZXing.Net" Version="0.16.10" />
     <PackageReference Include="System.Drawing.Common" Version="6.0.0" />
+    <PackageReference Include="ClosedXML" Version="0.102.4" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- add GroupSessionAttendanceDTO for export data
- expose domain method to collect session attendance per group
- provide API endpoint to download attendance Excel and add ClosedXML dependency

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b4bee599e883329b60239a808d7da5