### PR TITLE
Add course attendance summary endpoint

### DIFF
--- a/DAL/Contracts/IAttendanceRepository.cs
+++ b/DAL/Contracts/IAttendanceRepository.cs
@@ -13,5 +13,6 @@ namespace DAL.Contracts
         void RemoveAttendance(Guid attendanceId);
         bool HasAttendance(Guid sessionId, Guid studentId);
         int CountAttendances(Guid studentId, IEnumerable<Guid> sessionIds);
+        IEnumerable<CourseAttendanceSummary> GetCourseAttendanceByStudent(Guid studentId);
     }
 }

--- a/DTO/CourseAttendanceSummaryDTO.cs
+++ b/DTO/CourseAttendanceSummaryDTO.cs
@@ -1,0 +1,13 @@
+using System;
+
+namespace DTO
+{
+    public class CourseAttendanceSummaryDTO
+    {
+        public Guid CourseId { get; set; }
+        public string CourseName { get; set; } = null!;
+        public int TotalSessions { get; set; }
+        public int AttendedSessions { get; set; }
+        public int MissedSessions { get; set; }
+    }
+}

--- a/Domain/Concrete/AttendanceDomain.cs
+++ b/Domain/Concrete/AttendanceDomain.cs
@@ -41,6 +41,12 @@ namespace Domain.Concrete
             return _mapper.Map<IEnumerable<AttendanceDTO>>(items);
         }
 
+        public IEnumerable<CourseAttendanceSummaryDTO> GetCourseAttendanceByStudent(Guid studentCardId)
+        {
+            var items = AttendanceRepository.GetCourseAttendanceByStudent(studentCardId);
+            return _mapper.Map<IEnumerable<CourseAttendanceSummaryDTO>>(items);
+        }
+
         public AttendanceDTO AddAttendance(AttendanceAddDTO dto)
         {
             var teacherId = GetUserId();

--- a/Domain/Contracts/IAttendanceDomain.cs
+++ b/Domain/Contracts/IAttendanceDomain.cs
@@ -12,5 +12,6 @@ namespace Domain.Contracts
         AttendanceDTO AddAttendance(AttendanceAddDTO dto);
         void RemoveAttendance(Guid attendanceId);
         IEnumerable<GroupSessionAttendanceDTO> GetGroupSessionAttendance(Guid groupId, Guid sessionId);
+        IEnumerable<CourseAttendanceSummaryDTO> GetCourseAttendanceByStudent(Guid studentCardId);
     }
 }

--- a/Domain/Mappings/GeneralProfile.cs
+++ b/Domain/Mappings/GeneralProfile.cs
@@ -70,6 +70,7 @@ namespace Domain.Mappings
             #region attendance
             CreateMap<TblAttendance, AttendanceDTO>().ReverseMap();
             CreateMap<TblAttendance, AttendanceCheckInDTO>().ReverseMap();
+            CreateMap<CourseAttendanceSummary, CourseAttendanceSummaryDTO>().ReverseMap();
             #endregion
             #region studentCard
             CreateMap<TblStudentCard, StudentCardDTO>().ReverseMap();

--- a/Entities/Models/CourseAttendanceSummary.cs
+++ b/Entities/Models/CourseAttendanceSummary.cs
@@ -1,0 +1,13 @@
+using System;
+
+namespace Entities.Models
+{
+    public class CourseAttendanceSummary
+    {
+        public Guid CourseId { get; set; }
+        public string CourseName { get; set; } = null!;
+        public int TotalSessions { get; set; }
+        public int AttendedSessions { get; set; }
+        public int MissedSessions { get; set; }
+    }
+}

--- a/HumanResourceProject/Controllers/AttendanceController.cs
+++ b/HumanResourceProject/Controllers/AttendanceController.cs
@@ -32,6 +32,13 @@ namespace HumanResourceProject.Controllers
             return Ok(result);
         }
 
+        [HttpGet("student/{studentCardId}/courses")]
+        public IActionResult GetCourseAttendance(Guid studentCardId)
+        {
+            var result = _attendanceDomain.GetCourseAttendanceByStudent(studentCardId);
+            return Ok(result);
+        }
+
         [HttpGet("session/{sessionId}")]
         public IActionResult GetBySession(Guid sessionId)
         {


### PR DESCRIPTION
## Summary
- add model and DTO for course attendance summary
- compute per-course attendance for a student card
- expose GET endpoint to retrieve attendance totals by course

## Testing
- `dotnet build` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68b4c0a82ddc8332884f32cdcaa791bf