### PR TITLE
Add OTP expiry validation and scan check-in endpoint

### DIFF
--- a/DAL/Contracts/IAttendanceRepository.cs
+++ b/DAL/Contracts/IAttendanceRepository.cs
@@ -6,7 +6,8 @@ namespace DAL.Contracts
 {
     public interface IAttendanceRepository : IRepository<TblAttendance, Guid>
     {
-        TblAttendance CheckIn(string studentCardCode, Guid sessionId, string requestIp);
+        TblAttendance CheckIn(Guid studentId, string sessionOtp, string requestIp);
+        TblAttendance Scan(string studentCardCode, Guid sessionId);
         IEnumerable<TblAttendance> GetByStudent(Guid studentCardId);
         IEnumerable<TblAttendance> GetBySession(Guid sessionId);
         TblAttendance AddAttendance(Guid sessionId, Guid studentId, Guid teacherId);

--- a/DTO/AttendanceDTO.cs
+++ b/DTO/AttendanceDTO.cs
@@ -16,6 +16,12 @@ namespace DTO
 
     public class AttendanceCheckInDTO
     {
+        public Guid StudentId { get; set; }
+        public string SessionOtp { get; set; } = null!;
+    }
+
+    public class AttendanceScanDTO
+    {
         public string StudentCardCode { get; set; } = null!;
         public Guid SessionId { get; set; }
     }

--- a/Domain/Concrete/AttendanceDomain.cs
+++ b/Domain/Concrete/AttendanceDomain.cs
@@ -25,7 +25,13 @@ namespace Domain.Concrete
             var ipAddress = _httpContextAccessor.HttpContext?.Connection?.RemoteIpAddress?.ToString();
             if (string.IsNullOrEmpty(ipAddress))
                 throw new Exception("Unable to determine IP address");
-            var entity = AttendanceRepository.CheckIn(dto.StudentCardCode, dto.SessionId, ipAddress);
+            var entity = AttendanceRepository.CheckIn(dto.StudentId, dto.SessionOtp, ipAddress);
+            return _mapper.Map<AttendanceDTO>(entity);
+        }
+
+        public AttendanceDTO Scan(AttendanceScanDTO dto)
+        {
+            var entity = AttendanceRepository.Scan(dto.StudentCardCode, dto.SessionId);
             return _mapper.Map<AttendanceDTO>(entity);
         }
 

--- a/Domain/Contracts/IAttendanceDomain.cs
+++ b/Domain/Contracts/IAttendanceDomain.cs
@@ -7,6 +7,7 @@ namespace Domain.Contracts
     public interface IAttendanceDomain
     {
         AttendanceDTO CheckIn(AttendanceCheckInDTO dto);
+        AttendanceDTO Scan(AttendanceScanDTO dto);
         IEnumerable<AttendanceDTO> GetByStudentCardId(Guid studentCardId);
         IEnumerable<AttendanceDTO> GetBySessionId(Guid sessionId);
         AttendanceDTO AddAttendance(AttendanceAddDTO dto);

--- a/HumanResourceProject/Controllers/AttendanceController.cs
+++ b/HumanResourceProject/Controllers/AttendanceController.cs
@@ -25,6 +25,13 @@ namespace HumanResourceProject.Controllers
             return Ok(result);
         }
 
+        [HttpPost("scan")]
+        public IActionResult Scan([FromBody] AttendanceScanDTO dto)
+        {
+            var result = _attendanceDomain.Scan(dto);
+            return Ok(result);
+        }
+
         [HttpGet("student/{studentCardId}")]
         public IActionResult GetByStudent(Guid studentCardId)
         {


### PR DESCRIPTION
## Summary
- Enforce 30-minute expiration for session OTPs during student check-in
- Provide a new scan-based check-in endpoint using student card code and session ID without network validation

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b4c5c53378833289f0b8c09e22a179