### PR TITLE
Add endpoint to fetch latest open session

### DIFF
--- a/DAL/Concrete/SessionRepository.cs
+++ b/DAL/Concrete/SessionRepository.cs
@@ -113,6 +113,19 @@ namespace DAL.Concrete
                 .FirstOrDefault(s => s.Id == id && s.Status != EntityStatus.Deleted);
         }
 
+        public TblSession? GetLatestOpenSession(Guid scheduleId)
+        {
+            return context
+                .Include(s => s.Schedule).ThenInclude(sc => sc.Course).ThenInclude(c => c.Program)
+                .Include(s => s.Schedule).ThenInclude(sc => sc.Group)
+                .Include(s => s.Schedule).ThenInclude(sc => sc.Teacher).ThenInclude(t => t.User)
+                .Include(s => s.Schedule).ThenInclude(sc => sc.Room)
+                .Include(s => s.Schedule).ThenInclude(sc => sc.AcademicYear)
+                .Where(s => s.ScheduleId == scheduleId && s.IsOpen == true && s.Status != EntityStatus.Deleted)
+                .OrderByDescending(s => s.Date)
+                .FirstOrDefault();
+        }
+
         public IEnumerable<Guid> GetSessionIdsByCourseAndGroup(Guid courseId, Guid groupId, Guid academicYearId)
         {
             return context

--- a/DAL/Contracts/ISessionRepository.cs
+++ b/DAL/Contracts/ISessionRepository.cs
@@ -13,5 +13,6 @@ namespace DAL.Contracts
         TblSession CloseSession(Guid sessionId);
         PagedList<TblSession> GetSessions(QueryParameters queryParameters, Guid? teacherId = null);
         IEnumerable<Guid> GetSessionIdsByCourseAndGroup(Guid courseId, Guid groupId, Guid academicYearId);
+        TblSession? GetLatestOpenSession(Guid scheduleId);
     }
 }

--- a/Domain/Concrete/SessionDomain.cs
+++ b/Domain/Concrete/SessionDomain.cs
@@ -127,5 +127,11 @@ namespace Domain.Concrete
             }
             return _mapper.Map<SessionDTO>(session);
         }
+
+        public SessionDTO? GetLatestOpenSession(Guid scheduleId)
+        {
+            var session = SessionRepository.GetLatestOpenSession(scheduleId);
+            return session == null ? null : _mapper.Map<SessionDTO>(session);
+        }
     }
 }

--- a/Domain/Contracts/ISessionDomain.cs
+++ b/Domain/Contracts/ISessionDomain.cs
@@ -12,5 +12,6 @@ namespace Domain.Contracts
         Task<SessionDTO> CloseSession(Guid sessionId);
         Pagination<SessionDTO> GetAllSessions(QueryParameters queryParameters, Guid? teacherId);
         SessionDTO GetSessionById(Guid sessionId);
+        SessionDTO? GetLatestOpenSession(Guid scheduleId);
     }
 }

--- a/HumanResourceProject/Controllers/SessionController.cs
+++ b/HumanResourceProject/Controllers/SessionController.cs
@@ -41,5 +41,10 @@ namespace PostOfficeProject.Controllers
         [Route("{sessionId}")]
         public IActionResult GetById([FromRoute] Guid sessionId)
             => Ok(_sessionDomain.GetSessionById(sessionId));
+
+        [HttpGet]
+        [Route("schedule/{scheduleId}/latest-open")]
+        public IActionResult GetLatestOpenSession([FromRoute] Guid scheduleId)
+            => Ok(_sessionDomain.GetLatestOpenSession(scheduleId));
     }
 }


### PR DESCRIPTION
## Summary
- expose API to retrieve most recent open session for a schedule
- added domain and repository logic returning null when no open session exists

## Testing
- `dotnet test` *(command not found: dotnet)*
- `apt-get update` *(403 forbidden - repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b4ccf5c58c833298c9ad4606467430