### PR TITLE
Add group course attendance summary API

### DIFF
--- a/DAL/Contracts/IAttendanceRepository.cs
+++ b/DAL/Contracts/IAttendanceRepository.cs
@@ -15,5 +15,6 @@ namespace DAL.Contracts
         bool HasAttendance(Guid sessionId, Guid studentId);
         int CountAttendances(Guid studentId, IEnumerable<Guid> sessionIds);
         IEnumerable<CourseAttendanceSummary> GetCourseAttendanceByStudent(Guid studentId);
+        IEnumerable<GroupCourseAttendanceSummary> GetGroupCourseAttendance(Guid groupId, Guid courseId);
     }
 }

--- a/DTO/GroupCourseAttendanceSummaryDTO.cs
+++ b/DTO/GroupCourseAttendanceSummaryDTO.cs
@@ -1,0 +1,16 @@
+using System;
+
+namespace DTO
+{
+    public class GroupCourseAttendanceSummaryDTO
+    {
+        public Guid StudentId { get; set; }
+        public string StudentCardCode { get; set; } = null!;
+        public string FirstName { get; set; } = null!;
+        public string LastName { get; set; } = null!;
+        public int AttendedSessions { get; set; }
+        public int TotalSessions { get; set; }
+        public int MissedSessions { get; set; }
+        public int TotalPlannedSessions { get; set; }
+    }
+}

--- a/Domain/Concrete/AttendanceDomain.cs
+++ b/Domain/Concrete/AttendanceDomain.cs
@@ -53,6 +53,12 @@ namespace Domain.Concrete
             return _mapper.Map<IEnumerable<CourseAttendanceSummaryDTO>>(items);
         }
 
+        public IEnumerable<GroupCourseAttendanceSummaryDTO> GetGroupCourseAttendance(Guid groupId, Guid courseId)
+        {
+            var items = AttendanceRepository.GetGroupCourseAttendance(groupId, courseId);
+            return _mapper.Map<IEnumerable<GroupCourseAttendanceSummaryDTO>>(items);
+        }
+
         public AttendanceDTO AddAttendance(AttendanceAddDTO dto)
         {
             var teacherId = GetUserId();

--- a/Domain/Contracts/IAttendanceDomain.cs
+++ b/Domain/Contracts/IAttendanceDomain.cs
@@ -14,5 +14,6 @@ namespace Domain.Contracts
         void RemoveAttendance(Guid attendanceId);
         IEnumerable<GroupSessionAttendanceDTO> GetGroupSessionAttendance(Guid groupId, Guid sessionId);
         IEnumerable<CourseAttendanceSummaryDTO> GetCourseAttendanceByStudent(Guid studentCardId);
+        IEnumerable<GroupCourseAttendanceSummaryDTO> GetGroupCourseAttendance(Guid groupId, Guid courseId);
     }
 }

--- a/Domain/Mappings/GeneralProfile.cs
+++ b/Domain/Mappings/GeneralProfile.cs
@@ -71,6 +71,7 @@ namespace Domain.Mappings
             CreateMap<TblAttendance, AttendanceDTO>().ReverseMap();
             CreateMap<TblAttendance, AttendanceCheckInDTO>().ReverseMap();
             CreateMap<CourseAttendanceSummary, CourseAttendanceSummaryDTO>().ReverseMap();
+            CreateMap<GroupCourseAttendanceSummary, GroupCourseAttendanceSummaryDTO>().ReverseMap();
             #endregion
             #region studentCard
             CreateMap<TblStudentCard, StudentCardDTO>().ReverseMap();

--- a/Entities/Models/GroupCourseAttendanceSummary.cs
+++ b/Entities/Models/GroupCourseAttendanceSummary.cs
@@ -1,0 +1,16 @@
+using System;
+
+namespace Entities.Models
+{
+    public class GroupCourseAttendanceSummary
+    {
+        public Guid StudentId { get; set; }
+        public string StudentCardCode { get; set; } = null!;
+        public string FirstName { get; set; } = null!;
+        public string LastName { get; set; } = null!;
+        public int AttendedSessions { get; set; }
+        public int TotalSessions { get; set; }
+        public int MissedSessions { get; set; }
+        public int TotalPlannedSessions { get; set; }
+    }
+}

--- a/HumanResourceProject/Controllers/AttendanceController.cs
+++ b/HumanResourceProject/Controllers/AttendanceController.cs
@@ -46,6 +46,13 @@ namespace HumanResourceProject.Controllers
             return Ok(result);
         }
 
+        [HttpGet("group/{groupId}/course/{courseId}")]
+        public IActionResult GetGroupCourseAttendance(Guid groupId, Guid courseId)
+        {
+            var result = _attendanceDomain.GetGroupCourseAttendance(groupId, courseId);
+            return Ok(result);
+        }
+
         [HttpGet("session/{sessionId}")]
         public IActionResult GetBySession(Guid sessionId)
         {


### PR DESCRIPTION
## Summary
- add DTO/model and mapping for group course attendance summary
- implement repository/domain logic to compute attendance per student for a group's course
- expose new API endpoint to retrieve summary including attended, missed, total and planned sessions

## Testing
- `dotnet build` *(fails: command not found: dotnet)*
- `apt-get update` *(fails: The repository ... is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b5f58889c883329ef3f6a379ebfcef